### PR TITLE
feat(android): add themed launcher icon support

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@drawable/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_foreground"/>
 </adaptive-icon>


### PR DESCRIPTION
# This PR adds support for Android 13's [*Themed Launcher Icons*](https://www.android.com/android-13/#a13-your-phone-your-aesthetic)

## Examples:

- ### Normal icon for reference

###
###   <img src="https://github.com/user-attachments/assets/e8ec16f0-633d-401a-9cc8-8bc0d4ffc391" width="20%"/>

- ### Light Theme, Green Palette
###
###   <img src="https://github.com/user-attachments/assets/2bd9f950-cece-424b-80e7-c697505e71fa" width="20%"/>

- ### Dark Theme, Green Palette
###
###   <img src="https://github.com/user-attachments/assets/8e239de4-845b-46b7-947e-117808242ca6" width="20%"/>