### PR TITLE
Metadata related small fix

### DIFF
--- a/gui/resources/com.oppzippy.OpenSCQ30.desktop
+++ b/gui/resources/com.oppzippy.OpenSCQ30.desktop
@@ -6,5 +6,5 @@ Name=OpenSCQ30
 Exec=openscq30-gui
 Icon=com.oppzippy.OpenSCQ30
 Terminal=false
-Categories=Utility;
-Keywords=Soundcore;Bluetooth;Headphones;Q30;
+Categories=Utility;Settings;
+Keywords=Soundcore;Bluetooth;Wireless;Headphones;Earbuds;Q30;

--- a/gui/resources/com.oppzippy.OpenSCQ30.metainfo.xml
+++ b/gui/resources/com.oppzippy.OpenSCQ30.metainfo.xml
@@ -8,17 +8,6 @@
     <description>
         <p>Cross platform application for controlling settings of Soundcore headphones and earbuds.</p>
     </description>
-    <categories>
-        <category>Settings</category>
-    </categories>
-    <keywords>
-        <keyword>soundcore</keyword>
-        <keyword>bluetooth</keyword>
-        <keyword>wireless</keyword>
-        <keyword>headphones</keyword>
-        <keyword>earbuds</keyword>
-        <keyword>q30</keyword>
-    </keywords>
     <icon type="remote">https://raw.githubusercontent.com/Oppzippy/OpenSCQ30/f66a292401d8e157ffa3356e2e03eca1e8b7a860/gui/resources/com.oppzippy.OpenSCQ30.svg</icon>
     <url type="homepage">https://github.com/Oppzippy/OpenSCQ30</url>
     <url type="bugtracker">https://github.com/Oppzippy/OpenSCQ30/issues</url>


### PR DESCRIPTION
### metadata: Add other URLs

Add bugtracker, vcs-browser, and translate URLs

See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#url

### Move categories into the desktop file

> **Categories and keywords**
> If there’s a launchable defined for a desktop application, categories and keywords are pulled from the desktop file.
> Defining them separately in the Metainfo file will override the contents of the desktop file.

Source: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords