### PR TITLE
Fix assertion

### DIFF
--- a/lib/src/devices/soundcore/common/modules/equalizer/setting_handler.rs
+++ b/lib/src/devices/soundcore/common/modules/equalizer/setting_handler.rs
@@ -73,7 +73,7 @@ impl<
                 "there can't be more preset bands than there are total bands",
             );
             assert!(
-                PRESET_BANDS <= VISIBLE_BANDS,
+                PRESET_BANDS >= VISIBLE_BANDS,
                 "there can't be fewer preset bands than visible bands",
             );
         }


### PR DESCRIPTION
This assertion's predicate requires `PRESET_BANDS <= VISIBLE_BANDS` while its message requires `PRESET_BANDS >= VISIBLE_BANDS`. Semantically, this assertion's predicate should be changed into `PRESET_BANDS >= VISIBLE_BANDS`.