### PR TITLE
feat(lib): add support for Soundcore Liberty 2 Pro (A3909)

### DIFF
--- a/lib/i18n/arz/openscq30-lib.ftl
+++ b/lib/i18n/arz/openscq30-lib.ftl
@@ -13,6 +13,7 @@ soundcore-a3035 = Soundcore Space One
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3116 = Soundcore Motion+
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/de/openscq30-lib.ftl
+++ b/lib/i18n/de/openscq30-lib.ftl
@@ -90,6 +90,7 @@ soundcore-a3030 = Soundcore Life Tune Pro
 soundcore-a3031 = Soundcore Vortex
 soundcore-a3033 = Soundcore Life 2 Neo
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/en/openscq30-lib.ftl
+++ b/lib/i18n/en/openscq30-lib.ftl
@@ -9,6 +9,7 @@ soundcore-a3035 = Soundcore Space One
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3062 = Soundcore Space One Pro
 soundcore-a3116 = Soundcore Motion+
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3926 = Soundcore Life Dot 2S
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC

--- a/lib/i18n/es/openscq30-lib.ftl
+++ b/lib/i18n/es/openscq30-lib.ftl
@@ -10,6 +10,7 @@ soundcore-a3035 = Soundcore Space One
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3116 = Soundcore Motion+
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/fr/openscq30-lib.ftl
+++ b/lib/i18n/fr/openscq30-lib.ftl
@@ -11,6 +11,7 @@ soundcore-a3040 = Soundcore Space Q45
 soundcore-a3062 = Soundcore Space One Pro
 soundcore-a3116 = Soundcore Motion+
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/he/openscq30-lib.ftl
+++ b/lib/i18n/he/openscq30-lib.ftl
@@ -10,6 +10,7 @@ soundcore-a3035 = Soundcore Space One
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3116 = Soundcore Motion+
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/it/openscq30-lib.ftl
+++ b/lib/i18n/it/openscq30-lib.ftl
@@ -11,6 +11,7 @@ soundcore-a3035 = Soundcore Space One
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3116 = Soundcore Motion+
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/ja/openscq30-lib.ftl
+++ b/lib/i18n/ja/openscq30-lib.ftl
@@ -91,6 +91,7 @@ soundcore-a3031 = Soundcore Vortex
 soundcore-a3033 = Soundcore Life 2 Neo
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/i18n/tr/openscq30-lib.ftl
+++ b/lib/i18n/tr/openscq30-lib.ftl
@@ -17,6 +17,7 @@ soundcore-a3030 = Soundcore Life Tune Pro
 soundcore-a3031 = Soundcore Vortex
 soundcore-a3033 = Soundcore Life 2 Neo
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3948 = Soundcore A20i

--- a/lib/i18n/uk/openscq30-lib.ftl
+++ b/lib/i18n/uk/openscq30-lib.ftl
@@ -9,6 +9,7 @@ soundcore-a3035 = Soundcore Space One
 soundcore-a3040 = Soundcore Space Q45
 soundcore-a3116 = Soundcore Motion+
 soundcore-a3926 = Soundcore Life Dot 2S
+soundcore-a3909 = Soundcore Liberty 2 Pro
 soundcore-a3930 = Soundcore Liberty 2 Pro+
 soundcore-a3931 = Soundcore Life Dot 2 NC
 soundcore-a3933 = Soundcore Life Note 3

--- a/lib/src/devices/device_model.rs
+++ b/lib/src/devices/device_model.rs
@@ -41,6 +41,7 @@ pub enum DeviceModel {
     SoundcoreA3040,
     SoundcoreA3062,
     SoundcoreA3116,
+    SoundcoreA3909,
     SoundcoreA3926,
     SoundcoreA3930,
     SoundcoreA3931,
@@ -89,6 +90,7 @@ impl DeviceModel {
             Self::SoundcoreA3040 => new_soundcore_device!(soundcore::a3040),
             Self::SoundcoreA3062 => new_soundcore_device!(soundcore::a3062),
             Self::SoundcoreA3116 => new_soundcore_device!(soundcore::a3116),
+            Self::SoundcoreA3909 => new_soundcore_device!(soundcore::a3909),
             Self::SoundcoreA3926 => new_soundcore_device!(soundcore::a3926),
             Self::SoundcoreA3930 => new_soundcore_device!(soundcore::a3930),
             Self::SoundcoreA3931 | Self::SoundcoreA3935 => {
@@ -135,6 +137,7 @@ impl DeviceModel {
             Self::SoundcoreA3040 => new_soundcore_device!(soundcore::a3040),
             Self::SoundcoreA3062 => new_soundcore_device!(soundcore::a3062),
             Self::SoundcoreA3116 => new_soundcore_device!(soundcore::a3116),
+            Self::SoundcoreA3909 => new_soundcore_device!(soundcore::a3909),
             Self::SoundcoreA3926 => new_soundcore_device!(soundcore::a3926),
             Self::SoundcoreA3930 => new_soundcore_device!(soundcore::a3930),
             Self::SoundcoreA3931 | Self::SoundcoreA3935 => {

--- a/lib/src/devices/soundcore.rs
+++ b/lib/src/devices/soundcore.rs
@@ -7,6 +7,7 @@ pub mod a3035;
 pub mod a3040;
 pub mod a3062;
 pub mod a3116;
+pub mod a3909;
 pub mod a3926;
 pub mod a3930;
 pub mod a3931;

--- a/lib/src/devices/soundcore/a3909.rs
+++ b/lib/src/devices/soundcore/a3909.rs
@@ -1,0 +1,63 @@
+use std::collections::HashMap;
+
+use uuid::uuid;
+
+use crate::devices::soundcore::{
+    a3909::{packets::A3909StateUpdatePacket, state::A3909State},
+    common::{
+        device::SoundcoreDeviceConfig,
+        macros::soundcore_device,
+        modules::equalizer,
+        packet::{
+            ChecksumKind,
+            inbound::{SerialNumberAndFirmwareVersion, TryToPacket},
+            outbound::{RequestSerialNumberAndFirmwareVersion, RequestState, ToPacket},
+        },
+    },
+};
+use crate::connection::RfcommServiceSelectionStrategy;
+
+mod packets;
+mod state;
+
+soundcore_device!(
+    A3909State,
+    async |packet_io| {
+        let state_update_packet: A3909StateUpdatePacket = packet_io
+            .send_with_response(&RequestState::default().to_packet())
+            .await?
+            .try_to_packet()?;
+        let sn_and_firmware: SerialNumberAndFirmwareVersion = packet_io
+            .send_with_response(&RequestSerialNumberAndFirmwareVersion::default().to_packet())
+            .await?
+            .try_to_packet()?;
+        Ok(A3909State::new(state_update_packet, sn_and_firmware))
+    },
+    async |builder| {
+        builder.module_collection().add_state_update();
+        builder.equalizer_tws(equalizer::common_settings()).await;
+        builder.tws_status();
+        builder.dual_battery(5);
+        builder.serial_number_and_dual_firmware_version();
+    },
+    {
+        HashMap::from([
+            (
+                RequestState::COMMAND,
+                A3909StateUpdatePacket::default().to_packet(),
+            ),
+            (
+                RequestSerialNumberAndFirmwareVersion::COMMAND,
+                SerialNumberAndFirmwareVersion::default().to_packet(),
+            ),
+        ])
+    },
+    CONFIG,
+);
+
+const CONFIG: SoundcoreDeviceConfig = SoundcoreDeviceConfig {
+    checksum_kind: ChecksumKind::Suffix,
+    rfcomm_service_selection_strategy: RfcommServiceSelectionStrategy::Constant(uuid!(
+        "00001101-0000-1000-8000-00805f9b34fb"
+    )),
+};

--- a/lib/src/devices/soundcore/a3909/packets.rs
+++ b/lib/src/devices/soundcore/a3909/packets.rs
@@ -1,0 +1,3 @@
+mod state_update_packet;
+
+pub use state_update_packet::*;

--- a/lib/src/devices/soundcore/a3909/packets/state_update_packet.rs
+++ b/lib/src/devices/soundcore/a3909/packets/state_update_packet.rs
@@ -1,0 +1,191 @@
+use async_trait::async_trait;
+use nom::{
+    IResult, Parser,
+    combinator::{all_consuming, map},
+    error::{ContextError, ParseError, context},
+    number::complete::be_u32,
+};
+use tokio::sync::watch;
+
+use crate::{
+    api::device,
+    devices::soundcore::{
+        a3909::state::A3909State,
+        common::{
+            modules::ModuleCollection,
+            packet::{
+                self, Command,
+                inbound::{FromPacketBody, TryToPacket},
+                outbound::ToPacket,
+                parsing::take_bool,
+            },
+            packet_manager::PacketHandler,
+            state::Update,
+            structures::{
+                AgeRange, CommonEqualizerConfiguration, DualBattery, Gender, SoundModes, TwsStatus,
+            },
+        },
+    },
+};
+
+// A3909 (Soundcore Liberty 2 Pro)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct A3909StateUpdatePacket {
+    pub tws_status: TwsStatus,
+    pub battery: DualBattery,
+    pub equalizer_configuration: CommonEqualizerConfiguration<2, 8>,
+    pub gender: Gender,
+    pub age_range: AgeRange,
+    pub hear_id_is_enabled: bool,
+    pub hear_id_time: u32,
+    pub sound_modes: SoundModes,
+    pub side_tone: bool,
+}
+
+impl Default for A3909StateUpdatePacket {
+    fn default() -> Self {
+        Self {
+            tws_status: Default::default(),
+            battery: Default::default(),
+            equalizer_configuration: Default::default(),
+            gender: Default::default(),
+            age_range: Default::default(),
+            hear_id_is_enabled: Default::default(),
+            hear_id_time: Default::default(),
+            sound_modes: Default::default(),
+            side_tone: Default::default(),
+        }
+    }
+}
+
+impl FromPacketBody for A3909StateUpdatePacket {
+    type DirectionMarker = packet::InboundMarker;
+
+    fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context(
+            "a3909 state update packet",
+            all_consuming(map(
+                (
+                    TwsStatus::take,
+                    DualBattery::take,
+                    CommonEqualizerConfiguration::take,
+                    Gender::take,
+                    AgeRange::take,
+                    take_bool,
+                    be_u32,
+                    SoundModes::take,
+                    take_bool,
+                ),
+                |(
+                    tws_status,
+                    battery,
+                    equalizer_configuration,
+                    gender,
+                    age_range,
+                    hear_id_is_enabled,
+                    hear_id_time,
+                    sound_modes,
+                    side_tone,
+                )| {
+                    Self {
+                        tws_status,
+                        battery,
+                        equalizer_configuration,
+                        gender,
+                        age_range,
+                        hear_id_is_enabled,
+                        hear_id_time,
+                        sound_modes,
+                        side_tone,
+                    }
+                },
+            )),
+        )
+        .parse_complete(input)
+    }
+}
+
+impl ToPacket for A3909StateUpdatePacket {
+    type DirectionMarker = packet::InboundMarker;
+
+    fn command(&self) -> Command {
+        packet::inbound::STATE_COMMAND
+    }
+
+    fn body(&self) -> Vec<u8> {
+        self.tws_status
+            .bytes()
+            .into_iter()
+            .chain(self.battery.bytes())
+            .chain(self.equalizer_configuration.bytes())
+            .chain([self.gender.0, self.age_range.0])
+            .chain([self.hear_id_is_enabled as u8])
+            .chain(self.hear_id_time.to_be_bytes())
+            .chain(self.sound_modes.bytes())
+            .chain([self.side_tone as u8])
+            .collect()
+    }
+}
+
+struct StateUpdatePacketHandler {}
+
+#[async_trait]
+impl PacketHandler<A3909State> for StateUpdatePacketHandler {
+    async fn handle_packet(
+        &self,
+        state: &watch::Sender<A3909State>,
+        packet: &packet::Inbound,
+    ) -> device::Result<()> {
+        let packet: A3909StateUpdatePacket = packet.try_to_packet()?;
+        state.send_modify(|state| state.update(packet));
+        Ok(())
+    }
+}
+
+impl ModuleCollection<A3909State> {
+    pub fn add_state_update(&mut self) {
+        self.packet_handlers.set_handler(
+            packet::inbound::STATE_COMMAND,
+            Box::new(StateUpdatePacketHandler {}),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nom_language::error::VerboseError;
+
+    use crate::devices::soundcore::common::packet::inbound::TryToPacket;
+
+    use super::*;
+
+    #[test]
+    fn serialize_and_deserialize() {
+        let bytes = A3909StateUpdatePacket::default()
+            .to_packet()
+            .bytes_with_checksum();
+        let (_, packet) = packet::Inbound::take_with_checksum::<VerboseError<_>>(&bytes).unwrap();
+        let _: A3909StateUpdatePacket = packet.try_to_packet().unwrap();
+    }
+
+    #[test]
+    fn parse_live_packet() {
+        // Captured from a real Liberty 2 Pro (A3909) device
+        let body: &[u8] = &[
+            0x01, 0x01, 0x05, 0x05, 0x00, 0x00, 0xfe, 0xfe, 0x01, 0x01, 0x01, 0x0c, 0x0c, 0x0c,
+            0x0f, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x0c, 0x69,
+            0x8e, 0xa8, 0x67, 0x02, 0x01, 0x03, 0x00, 0x00,
+        ];
+        let result = A3909StateUpdatePacket::take::<VerboseError<_>>(body);
+        assert!(result.is_ok(), "parse failed: {:?}", result.err());
+        let (remaining, packet) = result.unwrap();
+        assert!(remaining.is_empty());
+        assert!(packet.tws_status.is_connected);
+        assert_eq!(packet.battery.left.level.0, 5);
+        assert_eq!(packet.battery.right.level.0, 5);
+        assert!(!packet.hear_id_is_enabled);
+        assert_eq!(packet.hear_id_time, 0x698ea867);
+    }
+}

--- a/lib/src/devices/soundcore/a3909/state.rs
+++ b/lib/src/devices/soundcore/a3909/state.rs
@@ -1,0 +1,79 @@
+use openscq30_lib_macros::Has;
+
+use crate::devices::soundcore::common::{
+    packet::inbound::SerialNumberAndFirmwareVersion,
+    state::Update,
+    structures::{
+        AgeRange, CommonEqualizerConfiguration, DualBattery, DualFirmwareVersion, Gender,
+        SerialNumber, SoundModes, TwsStatus,
+    },
+};
+
+use super::packets::A3909StateUpdatePacket;
+
+#[derive(Debug, Clone, PartialEq, Eq, Has)]
+pub struct A3909State {
+    tws_status: TwsStatus,
+    battery: DualBattery,
+    equalizer_configuration: CommonEqualizerConfiguration<2, 8>,
+    serial_number: SerialNumber,
+    dual_firmware_version: DualFirmwareVersion,
+    #[has(skip)]
+    gender: Gender,
+    #[has(skip)]
+    age_range: AgeRange,
+    #[has(skip)]
+    hear_id_is_enabled: bool,
+    #[has(skip)]
+    hear_id_time: u32,
+    #[has(skip)]
+    sound_modes: SoundModes,
+    #[has(skip)]
+    side_tone: bool,
+}
+
+impl A3909State {
+    pub fn new(
+        state_update_packet: A3909StateUpdatePacket,
+        sn_and_firmware: SerialNumberAndFirmwareVersion,
+    ) -> Self {
+        Self {
+            tws_status: state_update_packet.tws_status,
+            battery: state_update_packet.battery,
+            equalizer_configuration: state_update_packet.equalizer_configuration,
+            gender: state_update_packet.gender,
+            age_range: state_update_packet.age_range,
+            hear_id_is_enabled: state_update_packet.hear_id_is_enabled,
+            hear_id_time: state_update_packet.hear_id_time,
+            sound_modes: state_update_packet.sound_modes,
+            side_tone: state_update_packet.side_tone,
+            serial_number: sn_and_firmware.serial_number,
+            dual_firmware_version: sn_and_firmware.dual_firmware_version,
+        }
+    }
+}
+
+impl Update<A3909StateUpdatePacket> for A3909State {
+    fn update(&mut self, partial: A3909StateUpdatePacket) {
+        let A3909StateUpdatePacket {
+            tws_status,
+            battery,
+            equalizer_configuration,
+            gender,
+            age_range,
+            hear_id_is_enabled,
+            hear_id_time,
+            sound_modes,
+            side_tone,
+        } = partial;
+        self.tws_status = tws_status;
+        self.battery = battery;
+        self.equalizer_configuration = equalizer_configuration;
+        self.gender = gender;
+        self.age_range = age_range;
+        self.hear_id_is_enabled = hear_id_is_enabled;
+        self.hear_id_time = hear_id_time;
+        self.sound_modes = sound_modes;
+        self.side_tone = side_tone;
+    }
+}

--- a/tools/soundcore-device-faker/devices/a3909.toml
+++ b/tools/soundcore-device-faker/devices/a3909.toml
@@ -1,0 +1,35 @@
+name = "Soundcore Liberty 2 Pro"
+mac_address = "00:00:00:00:39:09"
+rfcomm_uuid = "00001101-0000-1000-8000-00805f9b34fb"
+
+[[responses]]
+# State update
+command = [1, 1]
+response = [
+    # tws_status: host=Left(0), is_connected=true(1)
+    0, 1,
+    # battery: left_level=5, right_level=5, left_charging=0, right_charging=0
+    5, 5, 0, 0,
+    # equalizer_configuration: preset_id=0xfefe (le), ch1 (8 bands), ch2 (8 bands)
+    254, 254,
+    120, 120, 120, 120, 120, 120, 120, 120,
+    120, 120, 120, 120, 120, 120, 120, 120,
+    # gender=0, age_range=0
+    0, 0,
+    # hear_id_is_enabled=0
+    0,
+    # hear_id_time=0 (be_u32)
+    0, 0, 0, 0,
+    # sound_modes: ambient=Normal(2), nc=Indoor(1), transparency=FullyTransparent(3), custom_nc=0
+    2, 1, 3, 0,
+    # side_tone=0
+    0,
+]
+
+[[responses]]
+# firmware version
+command = [1, 5]
+response = [
+    48, 48, 46, 48, 48, 48, 48, 46, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48, 48,
+    48, 48, 48,
+]


### PR DESCRIPTION
## Summary

- Adds `SoundcoreA3909` device model for the **Soundcore Liberty 2 Pro** (2019, model A3909)
- Packet format reverse-engineered by probing a real device over RFCOMM
- Exposes: EQ (8 bands × 2 channels, TWS-aware), TWS status, dual battery (max level 5), serial number & firmware version
- No button configuration in the state packet (confirmed by pressing all button combinations — single/double/long on left and right — without any byte changes)

## Packet structure (36-byte body)

| Bytes | Field | Size |
|-------|-------|------|
| 0–1 | TwsStatus | 2 |
| 2–5 | DualBattery (level, level, charging, charging) | 4 |
| 6–23 | EqualizerConfiguration<2,8> (preset_id le_u16 + 8×ch1 + 8×ch2) | 18 |
| 24 | Gender | 1 |
| 25 | AgeRange | 1 |
| 26 | HearId.is_enabled | 1 |
| 27–30 | HearId.time (be_u32) | 4 |
| 31–34 | SoundModes | 4 |
| 35 | side_tone | 1 |

Live captured body (MAC 98:52:3D:8C:BE:AF):
```
01 01 05 05 00 00 fe fe 01 01 01 0c 0c 0c 0f 0c
0c 0c 0c 0c 0c 0c 0c 0c 0c 0c 0c 69 8e a8 67 02
01 03 00 00
```

## Context

This device was previously broken because it was incorrectly matched to the A3930 parser (see issue #228). The A3930 parser uses `CustomHearId<2,8>` which requires ~39 bytes at offset 26, but A3909 only has 10 bytes remaining there, causing a parse failure.

## Test plan

- [x] `cargo test -p openscq30-lib a3909` — 2 unit tests pass (serialize_and_deserialize, parse_live_packet)
- [x] `cargo test -p openscq30-lib` — all 159 tests pass including `test_set_all_settings` for the new model
- [ ] Test with real device (A3909, MAC 98:52:3D:8C:BE:AF) — EQ changes apply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)