### PR TITLE
feat(lib): add support for a3968 (Soundcore Sport X20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ If there's a device not in this list that you want to see supported, check if th
 | A3955 | Soundcore P40i               |
 | A3957 | Soundcore Liberty 5          |
 | A3959 | Soundcore P30i / R50i NC     |
+| A3968 | Soundcore Sport X20          |
 
 ## Installing
 

--- a/lib/i18n/en/openscq30-lib.ftl
+++ b/lib/i18n/en/openscq30-lib.ftl
@@ -24,6 +24,7 @@ soundcore-a3952 = Soundcore Liberty 3 Pro
 soundcore-a3939 = Soundcore Life P3
 soundcore-a3935 = Soundcore Life A2 NC
 soundcore-a3959 = Soundcore P30i / R50i NC
+soundcore-a3968 = Soundcore Sport X20
 soundcore-a3955 = Soundcore P40i
 soundcore-a3957 = Soundcore Liberty 5
 soundcore-development = Soundcore Development Information

--- a/lib/src/devices/device_model.rs
+++ b/lib/src/devices/device_model.rs
@@ -55,6 +55,7 @@ pub enum DeviceModel {
     SoundcoreA3955,
     SoundcoreA3957,
     SoundcoreA3959,
+    SoundcoreA3968,
     SoundcoreA3947,
     SoundcoreA3948,
     SoundcoreA3949,
@@ -109,6 +110,7 @@ impl DeviceModel {
             Self::SoundcoreA3955 => new_soundcore_device!(soundcore::a3955),
             Self::SoundcoreA3957 => new_soundcore_device!(soundcore::a3957),
             Self::SoundcoreA3959 => new_soundcore_device!(soundcore::a3959),
+            Self::SoundcoreA3968 => new_soundcore_device!(soundcore::a3968),
             Self::SoundcoreDevelopment => new_soundcore_device!(soundcore::development),
         }
     }
@@ -156,6 +158,7 @@ impl DeviceModel {
             Self::SoundcoreA3955 => new_soundcore_device!(soundcore::a3955),
             Self::SoundcoreA3957 => new_soundcore_device!(soundcore::a3957),
             Self::SoundcoreA3959 => new_soundcore_device!(soundcore::a3959),
+            Self::SoundcoreA3968 => new_soundcore_device!(soundcore::a3968),
             Self::SoundcoreDevelopment => new_soundcore_device!(soundcore::development),
         }
     }

--- a/lib/src/devices/soundcore.rs
+++ b/lib/src/devices/soundcore.rs
@@ -22,6 +22,7 @@ pub mod a3952;
 pub mod a3955;
 pub mod a3957;
 pub mod a3959;
+pub mod a3968;
 pub mod common;
 pub mod development;
 

--- a/lib/src/devices/soundcore/a3959.rs
+++ b/lib/src/devices/soundcore/a3959.rs
@@ -18,10 +18,10 @@ use crate::devices::soundcore::common::{
     },
 };
 
-pub mod modules;
+mod modules;
 mod packets;
 mod state;
-pub mod structures;
+mod structures;
 
 soundcore_device!(
     state::A3959State,

--- a/lib/src/devices/soundcore/a3959.rs
+++ b/lib/src/devices/soundcore/a3959.rs
@@ -18,10 +18,10 @@ use crate::devices::soundcore::common::{
     },
 };
 
-mod modules;
+pub mod modules;
 mod packets;
 mod state;
-mod structures;
+pub mod structures;
 
 soundcore_device!(
     state::A3959State,

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -28,6 +28,7 @@ soundcore_device!(
             .await;
         builder.tws_status();
         builder.dual_battery(5);
+        builder.case_battery_level(5);
         builder.serial_number_and_dual_firmware_version();
     },
     {
@@ -99,6 +100,7 @@ mod tests {
                 SettingId::PresetEqualizerProfile,
                 Value::OptionalString(None),
             ),
+            (SettingId::CaseBatteryLevel, "2/5".into()),
         ]);
     }
 }

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -4,13 +4,18 @@ use crate::devices::soundcore::{
     a3968::{packets::inbound::A3968StateUpdatePacket, state::A3968State},
     common::{
         self,
-        device::fetch_state_from_state_update_packet,
         macros::soundcore_device,
-        modules::button_configuration::{
-            ButtonConfigurationSettings, ButtonDisableMode, ButtonSettings, COMMON_ACTIONS,
-            COMMON_ACTIONS_MINIMAL,
+        modules::{
+            auto_power_off::AutoPowerOffDuration,
+            button_configuration::{
+                ButtonConfigurationSettings, ButtonDisableMode, ButtonSettings, COMMON_ACTIONS,
+                COMMON_ACTIONS_MINIMAL,
+            },
         },
-        packet::outbound::{RequestState, ToPacket},
+        packet::{
+            inbound::TryToPacket,
+            outbound::{RequestState, ToPacket},
+        },
         structures::button_configuration::{
             ActionKind, Button, ButtonParseSettings, ButtonPressKind, EnabledFlagKind,
         },
@@ -25,7 +30,19 @@ mod structures;
 soundcore_device!(
     A3968State,
     async |packet_io| {
-        fetch_state_from_state_update_packet::<A3968State, A3968StateUpdatePacket>(packet_io).await
+        let state_update_packet: packets::inbound::A3968StateUpdatePacket = packet_io
+            .send_with_response(&RequestState.to_packet())
+            .await?
+            .try_to_packet()?;
+        let dual_connections_devices = if state_update_packet.dual_connections_enabled {
+            common::modules::dual_connections::take_dual_connection_devices(&packet_io).await?
+        } else {
+            Vec::new()
+        };
+        Ok(state::A3968State::new(
+            state_update_packet,
+            dual_connections_devices,
+        ))
     },
     async |builder| {
         builder.module_collection().add_state_update();
@@ -34,6 +51,9 @@ soundcore_device!(
             .equalizer_with_custom_hear_id_tws(common::modules::equalizer::common_settings())
             .await;
         builder.button_configuration(&BUTTON_CONFIGURATION_SETTINGS);
+        builder.dual_connections();
+        builder.auto_power_off(AutoPowerOffDuration::ten_twenty_thirty_sixty());
+        builder.touch_tone();
         builder.tws_status();
         builder.dual_battery(5);
         builder.case_battery_level(5);
@@ -161,6 +181,9 @@ mod tests {
             (SettingId::RightDoublePress, Some("NextSong").into()),
             (SettingId::LeftLongPress, Some("AmbientSoundMode").into()),
             (SettingId::RightLongPress, Some("AmbientSoundMode").into()),
+            (SettingId::DualConnections, true.into()),
+            (SettingId::AutoPowerOff, "30m".into()),
+            (SettingId::TouchTone, false.into()),
         ]);
     }
 }

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -54,6 +54,7 @@ soundcore_device!(
         builder.ambient_sound_mode_cycle_tws();
         builder.dual_connections();
         builder.auto_power_off(AutoPowerOffDuration::ten_twenty_thirty_sixty());
+        builder.surround_sound();
         builder.touch_tone();
         builder.tws_status();
         builder.dual_battery(5);
@@ -188,6 +189,7 @@ mod tests {
             (SettingId::DualConnections, true.into()),
             (SettingId::AutoPowerOff, "30m".into()),
             (SettingId::TouchTone, false.into()),
+            (SettingId::SurroundSound, true.into()),
         ]);
     }
 }

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -1,0 +1,86 @@
+use std::collections::HashMap;
+
+use crate::devices::soundcore::{
+    a3968::{packets::inbound::A3968StateUpdatePacket, state::A3968State},
+    common::{
+        device::fetch_state_from_state_update_packet,
+        macros::soundcore_device,
+        packet::outbound::{RequestState, ToPacket},
+    },
+};
+
+mod packets;
+mod state;
+
+soundcore_device!(
+    A3968State,
+    async |packet_io| {
+        fetch_state_from_state_update_packet::<A3968State, A3968StateUpdatePacket>(packet_io).await
+    },
+    async |builder| {
+        builder.module_collection().add_state_update();
+        builder.a3959_sound_modes();
+        builder.dual_battery(5);
+        builder.serial_number_and_dual_firmware_version();
+    },
+    {
+        HashMap::from([(
+            RequestState::COMMAND,
+            A3968StateUpdatePacket::default().to_packet(),
+        )])
+    },
+);
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::{
+        DeviceModel,
+        devices::soundcore::common::{
+            device::{SoundcoreDeviceConfig, test_utils::TestSoundcoreDevice},
+            packet,
+        },
+        settings::SettingId,
+    };
+
+    /// State update packet posted by "Hate9" in GitHub issue #170 (a different X20 unit).
+    #[tokio::test(start_paused = true)]
+    async fn parses_state_update_packet_from_issue_170() {
+        let device = TestSoundcoreDevice::new(
+            super::device_registry,
+            DeviceModel::SoundcoreA3968,
+            HashMap::from([(
+                packet::Command([1, 1]),
+                packet::Inbound::new(
+                    packet::Command([1, 1]),
+                    vec![
+                        0, 1, 5, 5, 0, 0, 48, 49, 46, 54, 53, 48, 49, 46, 54, 53, 51, 57, 54, 56,
+                        98, 48, 51, 56, 101, 50, 54, 98, 98, 101, 57, 97, 0, 0, 0, 0, 0, 2, 254,
+                        254, 120, 120, 120, 120, 120, 120, 120, 120, 120, 120, 255, 255, 255, 255,
+                        255, 255, 255, 255, 255, 48, 1, 1, 135, 114, 140, 142, 150, 145, 166, 134,
+                        60, 60, 135, 114, 140, 142, 150, 145, 166, 134, 60, 60, 255, 255, 255, 255,
+                        1, 151, 151, 140, 143, 151, 145, 165, 134, 60, 0, 151, 151, 140, 143, 151,
+                        145, 165, 134, 60, 0, 0, 0, 8, 97, 102, 48, 51, 68, 68, 55, 0, 50, 1, 0, 0,
+                        255, 54, 1, 0, 1, 0, 1, 2, 1, 255, 255, 255, 255, 255, 255, 255, 255, 255,
+                        255, 255, 255,
+                    ],
+                ),
+            )]),
+            SoundcoreDeviceConfig::default(),
+        )
+        .await;
+
+        device.assert_setting_values([
+            (SettingId::BatteryLevelLeft, "5/5".into()),
+            (SettingId::BatteryLevelRight, "5/5".into()),
+            (SettingId::IsChargingLeft, "No".into()),
+            (SettingId::IsChargingRight, "No".into()),
+            (SettingId::FirmwareVersionLeft, "01.65".into()),
+            (SettingId::FirmwareVersionRight, "01.65".into()),
+            (SettingId::SerialNumber, "3968b038e26bbe9a".into()),
+            (SettingId::AmbientSoundMode, "NoiseCanceling".into()),
+            (SettingId::NoiseCancelingMode, "Manual".into()),
+        ]);
+    }
+}

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -6,7 +6,14 @@ use crate::devices::soundcore::{
         self,
         device::fetch_state_from_state_update_packet,
         macros::soundcore_device,
+        modules::button_configuration::{
+            ButtonConfigurationSettings, ButtonDisableMode, ButtonSettings, COMMON_ACTIONS,
+            COMMON_ACTIONS_MINIMAL,
+        },
         packet::outbound::{RequestState, ToPacket},
+        structures::button_configuration::{
+            ActionKind, Button, ButtonParseSettings, ButtonPressKind, EnabledFlagKind,
+        },
     },
 };
 
@@ -26,6 +33,7 @@ soundcore_device!(
         builder
             .equalizer_with_custom_hear_id_tws(common::modules::equalizer::common_settings())
             .await;
+        builder.button_configuration(&BUTTON_CONFIGURATION_SETTINGS);
         builder.tws_status();
         builder.dual_battery(5);
         builder.case_battery_level(5);
@@ -38,6 +46,52 @@ soundcore_device!(
         )])
     },
 );
+
+pub const BUTTON_CONFIGURATION_SETTINGS: ButtonConfigurationSettings<6, 3> =
+    ButtonConfigurationSettings {
+        supports_set_all_packet: false,
+        ignore_enabled_flag: true,
+        order: [
+            Button::LeftSinglePress,
+            Button::RightSinglePress,
+            Button::LeftDoublePress,
+            Button::RightDoublePress,
+            Button::LeftLongPress,
+            Button::RightLongPress,
+        ],
+        settings: [
+            ButtonSettings {
+                parse_settings: ButtonParseSettings {
+                    enabled_flag_kind: EnabledFlagKind::None,
+                    action_kind: ActionKind::TwsLowBits,
+                },
+                button_id: 2,
+                press_kind: ButtonPressKind::Single,
+                available_actions: COMMON_ACTIONS_MINIMAL,
+                disable_mode: ButtonDisableMode::IndividualDisable,
+            },
+            ButtonSettings {
+                parse_settings: ButtonParseSettings {
+                    enabled_flag_kind: EnabledFlagKind::None,
+                    action_kind: ActionKind::TwsLowBits,
+                },
+                button_id: 0,
+                press_kind: ButtonPressKind::Double,
+                available_actions: COMMON_ACTIONS,
+                disable_mode: ButtonDisableMode::IndividualDisable,
+            },
+            ButtonSettings {
+                parse_settings: ButtonParseSettings {
+                    enabled_flag_kind: EnabledFlagKind::None,
+                    action_kind: ActionKind::TwsLowBits,
+                },
+                button_id: 1,
+                press_kind: ButtonPressKind::Long,
+                available_actions: COMMON_ACTIONS,
+                disable_mode: ButtonDisableMode::IndividualDisable,
+            },
+        ],
+    };
 
 #[cfg(test)]
 mod tests {
@@ -101,6 +155,12 @@ mod tests {
                 Value::OptionalString(None),
             ),
             (SettingId::CaseBatteryLevel, "2/5".into()),
+            (SettingId::LeftSinglePress, Some("VolumeDown").into()),
+            (SettingId::RightSinglePress, Some("PlayPause").into()),
+            (SettingId::LeftDoublePress, Some("VolumeUp").into()),
+            (SettingId::RightDoublePress, Some("NextSong").into()),
+            (SettingId::LeftLongPress, Some("AmbientSoundMode").into()),
+            (SettingId::RightLongPress, Some("AmbientSoundMode").into()),
         ]);
     }
 }

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -51,6 +51,7 @@ soundcore_device!(
             .equalizer_with_custom_hear_id_tws(common::modules::equalizer::common_settings())
             .await;
         builder.button_configuration(&BUTTON_CONFIGURATION_SETTINGS);
+        builder.ambient_sound_mode_cycle_tws();
         builder.dual_connections();
         builder.auto_power_off(AutoPowerOffDuration::ten_twenty_thirty_sixty());
         builder.touch_tone();
@@ -181,6 +182,9 @@ mod tests {
             (SettingId::RightDoublePress, Some("NextSong").into()),
             (SettingId::LeftLongPress, Some("AmbientSoundMode").into()),
             (SettingId::RightLongPress, Some("AmbientSoundMode").into()),
+            (SettingId::NormalModeInCycle, true.into()),
+            (SettingId::TransparencyModeInCycle, true.into()),
+            (SettingId::NoiseCancelingModeInCycle, true.into()),
             (SettingId::DualConnections, true.into()),
             (SettingId::AutoPowerOff, "30m".into()),
             (SettingId::TouchTone, false.into()),

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -86,6 +86,11 @@ mod tests {
             (SettingId::SerialNumber, "3968b038e26bbe9a".into()),
             (SettingId::AmbientSoundMode, "NoiseCanceling".into()),
             (SettingId::NoiseCancelingMode, "Manual".into()),
+            (SettingId::ManualNoiseCanceling, "Strong".into()),
+            (SettingId::AdaptiveNoiseCanceling, "HighNoise".into()),
+            (SettingId::WindNoiseSuppression, false.into()),
+            (SettingId::WindNoiseDetected, "false".into()),
+            (SettingId::TransparencyMode, "VocalMode".into()),
         ]);
     }
 }

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use crate::devices::soundcore::{
     a3968::{packets::inbound::A3968StateUpdatePacket, state::A3968State},
     common::{
+        self,
         device::fetch_state_from_state_update_packet,
         macros::soundcore_device,
         packet::outbound::{RequestState, ToPacket},
@@ -22,6 +23,9 @@ soundcore_device!(
     async |builder| {
         builder.module_collection().add_state_update();
         builder.a3968_sound_modes();
+        builder
+            .equalizer_with_custom_hear_id_tws(common::modules::equalizer::common_settings())
+            .await;
         builder.tws_status();
         builder.dual_battery(5);
         builder.serial_number_and_dual_firmware_version();
@@ -44,7 +48,7 @@ mod tests {
             device::{SoundcoreDeviceConfig, test_utils::TestSoundcoreDevice},
             packet,
         },
-        settings::SettingId,
+        settings::{SettingId, Value},
     };
 
     /// State update packet posted by "Hate9" in GitHub issue #170 (a different X20 unit).
@@ -91,6 +95,10 @@ mod tests {
             (SettingId::WindNoiseSuppression, false.into()),
             (SettingId::WindNoiseDetected, "false".into()),
             (SettingId::TransparencyMode, "VocalMode".into()),
+            (
+                SettingId::PresetEqualizerProfile,
+                Value::OptionalString(None),
+            ),
         ]);
     }
 }

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -20,6 +20,7 @@ soundcore_device!(
     async |builder| {
         builder.module_collection().add_state_update();
         builder.a3959_sound_modes();
+        builder.tws_status();
         builder.dual_battery(5);
         builder.serial_number_and_dual_firmware_version();
     },
@@ -72,6 +73,8 @@ mod tests {
         .await;
 
         device.assert_setting_values([
+            (SettingId::TwsStatus, "Connected".into()),
+            (SettingId::HostDevice, "Left".into()),
             (SettingId::BatteryLevelLeft, "5/5".into()),
             (SettingId::BatteryLevelRight, "5/5".into()),
             (SettingId::IsChargingLeft, "No".into()),

--- a/lib/src/devices/soundcore/a3968.rs
+++ b/lib/src/devices/soundcore/a3968.rs
@@ -9,8 +9,10 @@ use crate::devices::soundcore::{
     },
 };
 
+mod modules;
 mod packets;
 mod state;
+mod structures;
 
 soundcore_device!(
     A3968State,
@@ -19,7 +21,7 @@ soundcore_device!(
     },
     async |builder| {
         builder.module_collection().add_state_update();
-        builder.a3959_sound_modes();
+        builder.a3968_sound_modes();
         builder.tws_status();
         builder.dual_battery(5);
         builder.serial_number_and_dual_firmware_version();

--- a/lib/src/devices/soundcore/a3968/modules.rs
+++ b/lib/src/devices/soundcore/a3968/modules.rs
@@ -1,0 +1,18 @@
+use openscq30_lib_has::Has;
+
+use crate::devices::soundcore::common::device::SoundcoreDeviceBuilder;
+
+use super::structures::SoundModes;
+
+mod sound_modes;
+
+impl<StateType> SoundcoreDeviceBuilder<StateType>
+where
+    StateType: Has<SoundModes> + Send + Sync + Clone + 'static,
+{
+    pub fn a3968_sound_modes(&mut self) {
+        let packet_io_controller = self.packet_io_controller().clone();
+        self.module_collection()
+            .add_a3968_sound_modes(packet_io_controller);
+    }
+}

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
@@ -1,0 +1,42 @@
+mod setting_handler;
+
+use std::sync::Arc;
+
+use openscq30_lib_has::Has;
+use setting_handler::SoundModesSettingHandler;
+use strum::{EnumIter, EnumString, IntoStaticStr};
+
+use crate::{
+    api::settings::{CategoryId, SettingId},
+    devices::soundcore::{
+        a3968::structures::SoundModes,
+        common::{modules::ModuleCollection, packet::PacketIOController},
+    },
+    macros::enum_subset,
+};
+
+enum_subset! {
+    SettingId,
+    #[derive(EnumString, EnumIter, IntoStaticStr)]
+    enum SoundModeSetting {
+        AmbientSoundMode,
+        NoiseCancelingMode,
+        AdaptiveNoiseCanceling,
+        ManualNoiseCanceling,
+        WindNoiseSuppression,
+        WindNoiseDetected,
+        AdaptiveNoiseCancelingSensitivityLevel,
+        MultiSceneNoiseCanceling,
+    }
+}
+
+impl<T> ModuleCollection<T>
+where
+    T: Has<SoundModes> + Clone + Send + Sync,
+{
+    pub fn add_a3968_sound_modes(&mut self, packet_io: Arc<PacketIOController>) {
+        self.setting_manager
+            .add_handler(CategoryId::SoundModes, SoundModesSettingHandler);
+        self.add_partial_sound_modes_v2_with_migration(packet_io);
+    }
+}

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
@@ -20,12 +20,12 @@ enum_subset! {
     #[derive(EnumString, EnumIter, IntoStaticStr)]
     enum SoundModeSetting {
         AmbientSoundMode,
+        TransparencyMode,
         NoiseCancelingMode,
         AdaptiveNoiseCanceling,
         ManualNoiseCanceling,
         WindNoiseSuppression,
         WindNoiseDetected,
-        MultiSceneNoiseCanceling,
     }
 }
 

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
@@ -36,6 +36,6 @@ where
     pub fn add_a3968_sound_modes(&mut self, packet_io: Arc<PacketIOController>) {
         self.setting_manager
             .add_handler(CategoryId::SoundModes, SoundModesSettingHandler);
-        self.add_partial_sound_modes_v2_with_migration(packet_io);
+        self.add_partial_sound_modes_v2(packet_io);
     }
 }

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes.rs
@@ -25,7 +25,6 @@ enum_subset! {
         ManualNoiseCanceling,
         WindNoiseSuppression,
         WindNoiseDetected,
-        AdaptiveNoiseCancelingSensitivityLevel,
         MultiSceneNoiseCanceling,
     }
 }

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes/setting_handler.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes/setting_handler.rs
@@ -1,0 +1,118 @@
+use async_trait::async_trait;
+use openscq30_lib_has::Has;
+use strum::IntoEnumIterator;
+
+use crate::{
+    api::settings::{self, Range, Setting, SettingId, Value},
+    devices::soundcore::{
+        a3968::structures::{ManualNoiseCanceling, SoundModes},
+        common::{
+            self,
+            settings_manager::{SettingHandler, SettingHandlerError, SettingHandlerResult},
+        },
+    },
+    i18n::fl,
+};
+
+use super::SoundModeSetting;
+
+#[derive(Default)]
+pub struct SoundModesSettingHandler;
+
+#[async_trait]
+impl<T> SettingHandler<T> for SoundModesSettingHandler
+where
+    T: Has<SoundModes> + Send,
+{
+    fn settings(&self) -> Vec<SettingId> {
+        SoundModeSetting::iter().map(Into::into).collect()
+    }
+
+    fn get(&self, state: &T, setting_id: &SettingId) -> Option<Setting> {
+        let sound_modes = state.get();
+        let sound_mode_setting: SoundModeSetting = (*setting_id).try_into().ok()?;
+        Some(match sound_mode_setting {
+            SoundModeSetting::AmbientSoundMode => {
+                Setting::select_from_enum_all_variants(sound_modes.ambient_sound_mode)
+            }
+            SoundModeSetting::NoiseCancelingMode => {
+                Setting::select_from_enum_all_variants(sound_modes.noise_canceling_mode)
+            }
+            SoundModeSetting::AdaptiveNoiseCanceling => Setting::Information {
+                value: format!("{}/5", sound_modes.adaptive_noise_canceling.inner()),
+                translated_value: format!("{}/5", sound_modes.adaptive_noise_canceling.inner()),
+            },
+            SoundModeSetting::ManualNoiseCanceling => Setting::I32Range {
+                setting: settings::Range {
+                    range: 1..=5,
+                    step: 1,
+                },
+                value: sound_modes.manual_noise_canceling.inner().into(),
+            },
+            SoundModeSetting::WindNoiseSuppression => Setting::Toggle {
+                value: sound_modes.wind_noise.is_suppression_enabled,
+            },
+            SoundModeSetting::WindNoiseDetected => Setting::Information {
+                value: sound_modes.wind_noise.is_detected.to_string(),
+                translated_value: if sound_modes.wind_noise.is_detected {
+                    fl!("yes")
+                } else {
+                    fl!("no")
+                },
+            },
+            SoundModeSetting::AdaptiveNoiseCancelingSensitivityLevel => Setting::I32Range {
+                setting: Range {
+                    range: 0..=10,
+                    step: 1,
+                },
+                value: sound_modes
+                    .noise_canceling_adaptive_sensitivity_level
+                    .into(),
+            },
+            SoundModeSetting::MultiSceneNoiseCanceling => Setting::select_from_enum(
+                &[
+                    common::structures::NoiseCancelingMode::Transport,
+                    common::structures::NoiseCancelingMode::Outdoor,
+                    common::structures::NoiseCancelingMode::Indoor,
+                ],
+                sound_modes.multi_scene_anc,
+            ),
+        })
+    }
+
+    async fn set(
+        &self,
+        state: &mut T,
+        setting_id: &SettingId,
+        value: Value,
+    ) -> SettingHandlerResult<()> {
+        let sound_modes = state.get_mut();
+        let sound_mode_setting: SoundModeSetting = (*setting_id)
+            .try_into()
+            .expect("already filtered to valid values only by SettingsManager");
+        match sound_mode_setting {
+            SoundModeSetting::AmbientSoundMode => {
+                sound_modes.ambient_sound_mode = value.try_as_enum_variant()?;
+            }
+            SoundModeSetting::NoiseCancelingMode => {
+                sound_modes.noise_canceling_mode = value.try_as_enum_variant()?;
+            }
+            SoundModeSetting::AdaptiveNoiseCanceling => return Err(SettingHandlerError::ReadOnly),
+            SoundModeSetting::ManualNoiseCanceling => {
+                sound_modes.manual_noise_canceling =
+                    ManualNoiseCanceling::new(value.try_as_i32()? as u8);
+            }
+            SoundModeSetting::WindNoiseSuppression => {
+                sound_modes.wind_noise.is_suppression_enabled = value.try_as_bool()?;
+            }
+            SoundModeSetting::WindNoiseDetected => return Err(SettingHandlerError::ReadOnly),
+            SoundModeSetting::AdaptiveNoiseCancelingSensitivityLevel => {
+                sound_modes.noise_canceling_adaptive_sensitivity_level = value.try_as_i32()? as u8;
+            }
+            SoundModeSetting::MultiSceneNoiseCanceling => {
+                sound_modes.multi_scene_anc = value.try_as_enum_variant()?;
+            }
+        }
+        Ok(())
+    }
+}

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes/setting_handler.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes/setting_handler.rs
@@ -3,7 +3,7 @@ use openscq30_lib_has::Has;
 use strum::IntoEnumIterator;
 
 use crate::{
-    api::settings::{self, Range, Setting, SettingId, Value},
+    api::settings::{self, Setting, SettingId, Value},
     devices::soundcore::{
         a3968::structures::{ManualNoiseCanceling, SoundModes},
         common::{
@@ -60,15 +60,6 @@ where
                     fl!("no")
                 },
             },
-            SoundModeSetting::AdaptiveNoiseCancelingSensitivityLevel => Setting::I32Range {
-                setting: Range {
-                    range: 0..=10,
-                    step: 1,
-                },
-                value: sound_modes
-                    .noise_canceling_adaptive_sensitivity_level
-                    .into(),
-            },
             SoundModeSetting::MultiSceneNoiseCanceling => Setting::select_from_enum(
                 &[
                     common::structures::NoiseCancelingMode::Transport,
@@ -106,9 +97,6 @@ where
                 sound_modes.wind_noise.is_suppression_enabled = value.try_as_bool()?;
             }
             SoundModeSetting::WindNoiseDetected => return Err(SettingHandlerError::ReadOnly),
-            SoundModeSetting::AdaptiveNoiseCancelingSensitivityLevel => {
-                sound_modes.noise_canceling_adaptive_sensitivity_level = value.try_as_i32()? as u8;
-            }
             SoundModeSetting::MultiSceneNoiseCanceling => {
                 sound_modes.multi_scene_anc = value.try_as_enum_variant()?;
             }

--- a/lib/src/devices/soundcore/a3968/modules/sound_modes/setting_handler.rs
+++ b/lib/src/devices/soundcore/a3968/modules/sound_modes/setting_handler.rs
@@ -1,15 +1,13 @@
 use async_trait::async_trait;
+use openscq30_i18n::Translate;
 use openscq30_lib_has::Has;
 use strum::IntoEnumIterator;
 
 use crate::{
-    api::settings::{self, Setting, SettingId, Value},
+    api::settings::{Setting, SettingId, Value},
     devices::soundcore::{
-        a3968::structures::{ManualNoiseCanceling, SoundModes},
-        common::{
-            self,
-            settings_manager::{SettingHandler, SettingHandlerError, SettingHandlerResult},
-        },
+        a3968::structures::SoundModes,
+        common::settings_manager::{SettingHandler, SettingHandlerError, SettingHandlerResult},
     },
     i18n::fl,
 };
@@ -35,20 +33,19 @@ where
             SoundModeSetting::AmbientSoundMode => {
                 Setting::select_from_enum_all_variants(sound_modes.ambient_sound_mode)
             }
+            SoundModeSetting::TransparencyMode => {
+                Setting::select_from_enum_all_variants(sound_modes.transparency_mode)
+            }
             SoundModeSetting::NoiseCancelingMode => {
                 Setting::select_from_enum_all_variants(sound_modes.noise_canceling_mode)
             }
             SoundModeSetting::AdaptiveNoiseCanceling => Setting::Information {
-                value: format!("{}/5", sound_modes.adaptive_noise_canceling.inner()),
-                translated_value: format!("{}/5", sound_modes.adaptive_noise_canceling.inner()),
+                value: sound_modes.adaptive_noise_canceling.to_string(),
+                translated_value: sound_modes.adaptive_noise_canceling.translate(),
             },
-            SoundModeSetting::ManualNoiseCanceling => Setting::I32Range {
-                setting: settings::Range {
-                    range: 1..=5,
-                    step: 1,
-                },
-                value: sound_modes.manual_noise_canceling.inner().into(),
-            },
+            SoundModeSetting::ManualNoiseCanceling => {
+                Setting::select_from_enum_all_variants(sound_modes.manual_noise_canceling)
+            }
             SoundModeSetting::WindNoiseSuppression => Setting::Toggle {
                 value: sound_modes.wind_noise.is_suppression_enabled,
             },
@@ -60,14 +57,6 @@ where
                     fl!("no")
                 },
             },
-            SoundModeSetting::MultiSceneNoiseCanceling => Setting::select_from_enum(
-                &[
-                    common::structures::NoiseCancelingMode::Transport,
-                    common::structures::NoiseCancelingMode::Outdoor,
-                    common::structures::NoiseCancelingMode::Indoor,
-                ],
-                sound_modes.multi_scene_anc,
-            ),
         })
     }
 
@@ -85,21 +74,20 @@ where
             SoundModeSetting::AmbientSoundMode => {
                 sound_modes.ambient_sound_mode = value.try_as_enum_variant()?;
             }
+            SoundModeSetting::TransparencyMode => {
+                sound_modes.transparency_mode = value.try_as_enum_variant()?;
+            }
             SoundModeSetting::NoiseCancelingMode => {
                 sound_modes.noise_canceling_mode = value.try_as_enum_variant()?;
             }
             SoundModeSetting::AdaptiveNoiseCanceling => return Err(SettingHandlerError::ReadOnly),
             SoundModeSetting::ManualNoiseCanceling => {
-                sound_modes.manual_noise_canceling =
-                    ManualNoiseCanceling::new(value.try_as_i32()? as u8);
+                sound_modes.manual_noise_canceling = value.try_as_enum_variant()?;
             }
             SoundModeSetting::WindNoiseSuppression => {
                 sound_modes.wind_noise.is_suppression_enabled = value.try_as_bool()?;
             }
             SoundModeSetting::WindNoiseDetected => return Err(SettingHandlerError::ReadOnly),
-            SoundModeSetting::MultiSceneNoiseCanceling => {
-                sound_modes.multi_scene_anc = value.try_as_enum_variant()?;
-            }
         }
         Ok(())
     }

--- a/lib/src/devices/soundcore/a3968/packets.rs
+++ b/lib/src/devices/soundcore/a3968/packets.rs
@@ -1,0 +1,1 @@
+pub mod inbound;

--- a/lib/src/devices/soundcore/a3968/packets/inbound.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound.rs
@@ -1,0 +1,3 @@
+mod state_update;
+
+pub use state_update::A3968StateUpdatePacket;

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -22,9 +22,9 @@ use crate::{
             packet_manager::PacketHandler,
             state::Update,
             structures::{
-                AutoPowerOff, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId,
-                DualBattery, DualFirmwareVersion, SerialNumber, TouchTone, TwsStatus,
-                button_configuration::ButtonStatusCollection,
+                AmbientSoundModeCycleTws, AutoPowerOff, CaseBatteryLevel,
+                CommonEqualizerConfiguration, CustomHearId, DualBattery, DualFirmwareVersion,
+                SerialNumber, TouchTone, TwsStatus, button_configuration::ButtonStatusCollection,
             },
         },
     },
@@ -52,6 +52,7 @@ pub struct A3968StateUpdatePacket {
     pub equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
     pub hear_id: CustomHearId<2, 10>,
     pub button_configuration: ButtonStatusCollection<6>,
+    pub ambient_sound_mode_cycle: AmbientSoundModeCycleTws,
     pub sound_modes: a3968::structures::SoundModes,
     pub dual_connections_enabled: bool,
     pub touch_tone: TouchTone,
@@ -69,6 +70,7 @@ impl Default for A3968StateUpdatePacket {
             equalizer_configuration: Default::default(),
             hear_id: Default::default(),
             button_configuration: a3968::BUTTON_CONFIGURATION_SETTINGS.default_status_collection(),
+            ambient_sound_mode_cycle: Default::default(),
             sound_modes: Default::default(),
             touch_tone: Default::default(),
             auto_power_off: Default::default(),
@@ -100,7 +102,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     ButtonStatusCollection::take(
                         a3968::BUTTON_CONFIGURATION_SETTINGS.parse_settings(),
                     ),
-                    take(1usize),                        // unknown,
+                    AmbientSoundModeCycleTws::take,
                     a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
                     take(1usize),                        // unknown
                     take_bool,                           // 3d surround sound
@@ -121,7 +123,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     hear_id,
                     _unknown3,
                     button_configuration,
-                    _unknown4,
+                    ambient_sound_mode_cycle,
                     sound_modes,
                     _unknown5,
                     _3d_surround_sound,
@@ -139,6 +141,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                         equalizer_configuration,
                         hear_id,
                         button_configuration,
+                        ambient_sound_mode_cycle,
                         sound_modes,
                         dual_connections_enabled,
                         touch_tone,
@@ -175,7 +178,7 @@ impl ToPacket for A3968StateUpdatePacket {
                 self.button_configuration
                     .bytes(a3968::BUTTON_CONFIGURATION_SETTINGS.parse_settings()),
             )
-            .chain(std::iter::once(0))
+            .chain(self.ambient_sound_mode_cycle.bytes())
             .chain(self.sound_modes.bytes())
             .chain(std::iter::once(0)) // unknown
             .chain(std::iter::once(0)) // 3d surround sound

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -10,8 +10,7 @@ use tokio::sync::watch;
 use crate::{
     api::device,
     devices::soundcore::{
-        a3959,
-        a3968::state::A3968State,
+        a3968::{self, state::A3968State},
         common::{
             modules::ModuleCollection,
             packet::{
@@ -35,7 +34,7 @@ use crate::{
 ///   32..117  equalizer (preset id + 8 bands at offset 38, 120 = 0.0 dB) + right-channel /
 ///            HearID data + reserved. Left unparsed for now: the X20 ignores every standard
 ///            EQ "set" command, so EQ is deferred to a follow-up once that's reverse-engineered.
-///   117..124 sound-mode block (A3959 format: ambient sound mode at offset 117)
+///   117..124 sound-mode block (A3968 format: ambient sound mode at offset 117)
 ///   124..143 reserved
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct A3968StateUpdatePacket {
@@ -43,7 +42,7 @@ pub struct A3968StateUpdatePacket {
     pub dual_battery: DualBattery,
     pub dual_firmware_version: DualFirmwareVersion,
     pub serial_number: SerialNumber,
-    pub sound_modes: a3959::structures::SoundModes,
+    pub sound_modes: a3968::structures::SoundModes,
 }
 
 impl FromPacketBody for A3968StateUpdatePacket {
@@ -61,7 +60,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     DualFirmwareVersion::take,           // 10 bytes
                     SerialNumber::take,                  // 16 bytes
                     take(85usize), // equalizer + HearID + reserved (offsets 32..117)
-                    a3959::structures::SoundModes::take, // sound-mode block (offsets 117..124)
+                    a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
                     take(19usize), // reserved (offsets 124..143)
                 ),
                 |(

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -22,6 +22,7 @@ use crate::{
             structures::{
                 CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
                 DualFirmwareVersion, SerialNumber, TwsStatus,
+                button_configuration::ButtonStatusCollection,
             },
         },
     },
@@ -39,7 +40,7 @@ use crate::{
 ///            EQ "set" command, so EQ is deferred to a follow-up once that's reverse-engineered.
 ///   117..124 sound-mode block (A3968 format: ambient sound mode at offset 117)
 ///   124..143 reserved
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct A3968StateUpdatePacket {
     pub tws_status: TwsStatus,
     pub dual_battery: DualBattery,
@@ -48,7 +49,24 @@ pub struct A3968StateUpdatePacket {
     pub case_battery_level: CaseBatteryLevel,
     pub equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
     pub hear_id: CustomHearId<2, 10>,
+    pub button_configuration: ButtonStatusCollection<6>,
     pub sound_modes: a3968::structures::SoundModes,
+}
+
+impl Default for A3968StateUpdatePacket {
+    fn default() -> Self {
+        Self {
+            tws_status: Default::default(),
+            dual_battery: Default::default(),
+            dual_firmware_version: Default::default(),
+            serial_number: Default::default(),
+            case_battery_level: Default::default(),
+            equalizer_configuration: Default::default(),
+            hear_id: Default::default(),
+            button_configuration: a3968::BUTTON_CONFIGURATION_SETTINGS.default_status_collection(),
+            sound_modes: Default::default(),
+        }
+    }
 }
 
 impl FromPacketBody for A3968StateUpdatePacket {
@@ -70,8 +88,10 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     CommonEqualizerConfiguration::take,
                     take(1usize), // unknown
                     CustomHearId::take_with_music_genre_at_end,
-                    take(1usize),                        // unknown,
-                    take(6usize),                        // TODO button configuration,
+                    take(1usize), // unknown,
+                    ButtonStatusCollection::take(
+                        a3968::BUTTON_CONFIGURATION_SETTINGS.parse_settings(),
+                    ),
                     take(1usize),                        // unknown,
                     a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
                 ),
@@ -86,7 +106,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     _unknown2,
                     hear_id,
                     _unknown3,
-                    _todo_button_configuration,
+                    button_configuration,
                     _unknown4,
                     sound_modes,
                 )| {
@@ -98,6 +118,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                         case_battery_level,
                         equalizer_configuration,
                         hear_id,
+                        button_configuration,
                         sound_modes,
                     }
                 },
@@ -127,7 +148,10 @@ impl ToPacket for A3968StateUpdatePacket {
             .chain(std::iter::once(0))
             .chain(self.hear_id.bytes_with_music_genre_at_end())
             .chain(std::iter::once(0))
-            .chain(std::iter::repeat_n(0, 6)) // TODO button configuration
+            .chain(
+                self.button_configuration
+                    .bytes(a3968::BUTTON_CONFIGURATION_SETTINGS.parse_settings()),
+            )
             .chain(std::iter::once(0))
             .chain(self.sound_modes.bytes())
             .collect()

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -69,15 +69,9 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     dual_firmware_version,
                     serial_number,
                     _eq_and_reserved,
-                    mut sound_modes,
+                    sound_modes,
                     _reserved,
                 )| {
-                    // The device reports a live adaptive-sensitivity byte (255) and wind flags
-                    // that are invalid as inputs and make the X20 reject NoiseCanceling on set.
-                    // Normalize them so the set path always emits clean, accepted values.
-                    sound_modes.noise_canceling_adaptive_sensitivity_level = 0;
-                    sound_modes.wind_noise.is_suppression_enabled = false;
-                    sound_modes.wind_noise.is_detected = false;
                     Self {
                         tws_status,
                         dual_battery,

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use nom::{
     IResult, Parser,
     bytes::complete::take,
-    combinator::{all_consuming, map},
+    combinator::map,
     error::{ContextError, ParseError, context},
 };
 use tokio::sync::watch;
@@ -53,7 +53,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
     ) -> IResult<&'a [u8], Self, E> {
         context(
             "a3968 state update packet",
-            all_consuming(map(
+            map(
                 (
                     TwsStatus::take,                     // tws status (host, both-connected)
                     DualBattery::take,                   // 4 bytes
@@ -61,7 +61,6 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     SerialNumber::take,                  // 16 bytes
                     take(85usize), // equalizer + HearID + reserved (offsets 32..117)
                     a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
-                    take(19usize), // reserved (offsets 124..143)
                 ),
                 |(
                     tws_status,
@@ -70,7 +69,6 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     serial_number,
                     _eq_and_reserved,
                     sound_modes,
-                    _reserved,
                 )| {
                     Self {
                         tws_status,
@@ -80,7 +78,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                         sound_modes,
                     }
                 },
-            )),
+            ),
         )
         .parse_complete(input)
     }

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -19,7 +19,10 @@ use crate::{
                 outbound::ToPacket,
             },
             packet_manager::PacketHandler,
-            structures::{DualBattery, DualFirmwareVersion, SerialNumber, TwsStatus},
+            structures::{
+                CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
+                DualFirmwareVersion, SerialNumber, TwsStatus,
+            },
         },
     },
 };
@@ -42,6 +45,9 @@ pub struct A3968StateUpdatePacket {
     pub dual_battery: DualBattery,
     pub dual_firmware_version: DualFirmwareVersion,
     pub serial_number: SerialNumber,
+    pub case_battery_level: CaseBatteryLevel,
+    pub equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
+    pub hear_id: CustomHearId<2, 10>,
     pub sound_modes: a3968::structures::SoundModes,
 }
 
@@ -55,11 +61,18 @@ impl FromPacketBody for A3968StateUpdatePacket {
             "a3968 state update packet",
             map(
                 (
-                    TwsStatus::take,                     // tws status (host, both-connected)
-                    DualBattery::take,                   // 4 bytes
-                    DualFirmwareVersion::take,           // 10 bytes
-                    SerialNumber::take,                  // 16 bytes
-                    take(85usize), // equalizer + HearID + reserved (offsets 32..117)
+                    TwsStatus::take,           // tws status (host, both-connected)
+                    DualBattery::take,         // 4 bytes
+                    DualFirmwareVersion::take, // 10 bytes
+                    SerialNumber::take,        // 16 bytes
+                    take(5usize),              // unknown
+                    CaseBatteryLevel::take,
+                    CommonEqualizerConfiguration::take,
+                    take(1usize), // unknown
+                    CustomHearId::take_with_music_genre_at_end,
+                    take(1usize),                        // unknown,
+                    take(6usize),                        // TODO button configuration,
+                    take(1usize),                        // unknown,
                     a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
                 ),
                 |(
@@ -67,7 +80,14 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     dual_battery,
                     dual_firmware_version,
                     serial_number,
-                    _eq_and_reserved,
+                    _unknown1,
+                    case_battery_level,
+                    equalizer_configuration,
+                    _unknown2,
+                    hear_id,
+                    _unknown3,
+                    _todo_button_configuration,
+                    _unknown4,
                     sound_modes,
                 )| {
                     Self {
@@ -75,6 +95,9 @@ impl FromPacketBody for A3968StateUpdatePacket {
                         dual_battery,
                         dual_firmware_version,
                         serial_number,
+                        case_battery_level,
+                        equalizer_configuration,
+                        hear_id,
                         sound_modes,
                     }
                 },
@@ -98,9 +121,15 @@ impl ToPacket for A3968StateUpdatePacket {
             .chain(self.dual_battery.bytes())
             .chain(self.dual_firmware_version.bytes())
             .chain(self.serial_number.bytes())
-            .chain(std::iter::repeat_n(0u8, 85))
+            .chain(std::iter::repeat_n(0, 5))
+            .chain(self.case_battery_level.bytes())
+            .chain(self.equalizer_configuration.bytes())
+            .chain(std::iter::once(0))
+            .chain(self.hear_id.bytes_with_music_genre_at_end())
+            .chain(std::iter::once(0))
+            .chain(std::iter::repeat_n(0, 6)) // TODO button configuration
+            .chain(std::iter::once(0))
             .chain(self.sound_modes.bytes())
-            .chain(std::iter::repeat_n(0u8, 19))
             .collect()
     }
 }

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -17,11 +17,13 @@ use crate::{
                 self, Command,
                 inbound::{FromPacketBody, TryToPacket},
                 outbound::ToPacket,
+                parsing::take_bool,
             },
             packet_manager::PacketHandler,
+            state::Update,
             structures::{
-                CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
-                DualFirmwareVersion, SerialNumber, TwsStatus,
+                AutoPowerOff, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId,
+                DualBattery, DualFirmwareVersion, SerialNumber, TouchTone, TwsStatus,
                 button_configuration::ButtonStatusCollection,
             },
         },
@@ -51,6 +53,9 @@ pub struct A3968StateUpdatePacket {
     pub hear_id: CustomHearId<2, 10>,
     pub button_configuration: ButtonStatusCollection<6>,
     pub sound_modes: a3968::structures::SoundModes,
+    pub dual_connections_enabled: bool,
+    pub touch_tone: TouchTone,
+    pub auto_power_off: AutoPowerOff,
 }
 
 impl Default for A3968StateUpdatePacket {
@@ -65,6 +70,9 @@ impl Default for A3968StateUpdatePacket {
             hear_id: Default::default(),
             button_configuration: a3968::BUTTON_CONFIGURATION_SETTINGS.default_status_collection(),
             sound_modes: Default::default(),
+            touch_tone: Default::default(),
+            auto_power_off: Default::default(),
+            dual_connections_enabled: Default::default(),
         }
     }
 }
@@ -94,6 +102,12 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     ),
                     take(1usize),                        // unknown,
                     a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
+                    take(1usize),                        // unknown
+                    take_bool,                           // 3d surround sound
+                    take(1usize),                        // unknown
+                    take_bool,                           // dual connections enabled
+                    TouchTone::take,
+                    AutoPowerOff::take,
                 ),
                 |(
                     tws_status,
@@ -109,6 +123,12 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     button_configuration,
                     _unknown4,
                     sound_modes,
+                    _unknown5,
+                    _3d_surround_sound,
+                    _unknown6,
+                    dual_connections_enabled,
+                    touch_tone,
+                    auto_power_off,
                 )| {
                     Self {
                         tws_status,
@@ -120,6 +140,9 @@ impl FromPacketBody for A3968StateUpdatePacket {
                         hear_id,
                         button_configuration,
                         sound_modes,
+                        dual_connections_enabled,
+                        touch_tone,
+                        auto_power_off,
                     }
                 },
             ),
@@ -154,6 +177,12 @@ impl ToPacket for A3968StateUpdatePacket {
             )
             .chain(std::iter::once(0))
             .chain(self.sound_modes.bytes())
+            .chain(std::iter::once(0)) // unknown
+            .chain(std::iter::once(0)) // 3d surround sound
+            .chain(std::iter::once(0)) // unknown
+            .chain(std::iter::once(self.dual_connections_enabled as u8))
+            .chain(self.touch_tone.bytes())
+            .chain(self.auto_power_off.bytes())
             .collect()
     }
 }
@@ -168,7 +197,7 @@ impl PacketHandler<A3968State> for StateUpdatePacketHandler {
         packet: &packet::Inbound,
     ) -> device::Result<()> {
         let packet: A3968StateUpdatePacket = packet.try_to_packet()?;
-        state.send_modify(|state| *state = packet.into());
+        state.send_modify(|state| state.update(packet));
         Ok(())
     }
 }

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -24,7 +24,8 @@ use crate::{
             structures::{
                 AmbientSoundModeCycleTws, AutoPowerOff, CaseBatteryLevel,
                 CommonEqualizerConfiguration, CustomHearId, DualBattery, DualFirmwareVersion,
-                SerialNumber, TouchTone, TwsStatus, button_configuration::ButtonStatusCollection,
+                SerialNumber, SurroundSound, TouchTone, TwsStatus,
+                button_configuration::ButtonStatusCollection,
             },
         },
     },
@@ -57,6 +58,7 @@ pub struct A3968StateUpdatePacket {
     pub dual_connections_enabled: bool,
     pub touch_tone: TouchTone,
     pub auto_power_off: AutoPowerOff,
+    pub surround_sound: SurroundSound,
 }
 
 impl Default for A3968StateUpdatePacket {
@@ -75,6 +77,7 @@ impl Default for A3968StateUpdatePacket {
             touch_tone: Default::default(),
             auto_power_off: Default::default(),
             dual_connections_enabled: Default::default(),
+            surround_sound: Default::default(),
         }
     }
 }
@@ -105,9 +108,9 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     AmbientSoundModeCycleTws::take,
                     a3968::structures::SoundModes::take, // sound-mode block (offsets 117..124)
                     take(1usize),                        // unknown
-                    take_bool,                           // 3d surround sound
-                    take(1usize),                        // unknown
-                    take_bool,                           // dual connections enabled
+                    SurroundSound::take,
+                    take(1usize), // unknown
+                    take_bool,    // dual connections enabled
                     TouchTone::take,
                     AutoPowerOff::take,
                 ),
@@ -126,7 +129,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     ambient_sound_mode_cycle,
                     sound_modes,
                     _unknown5,
-                    _3d_surround_sound,
+                    surround_sound,
                     _unknown6,
                     dual_connections_enabled,
                     touch_tone,
@@ -146,6 +149,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                         dual_connections_enabled,
                         touch_tone,
                         auto_power_off,
+                        surround_sound,
                     }
                 },
             ),
@@ -181,7 +185,7 @@ impl ToPacket for A3968StateUpdatePacket {
             .chain(self.ambient_sound_mode_cycle.bytes())
             .chain(self.sound_modes.bytes())
             .chain(std::iter::once(0)) // unknown
-            .chain(std::iter::once(0)) // 3d surround sound
+            .chain(self.surround_sound.bytes())
             .chain(std::iter::once(0)) // unknown
             .chain(std::iter::once(self.dual_connections_enabled as u8))
             .chain(self.touch_tone.bytes())

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -1,0 +1,136 @@
+use async_trait::async_trait;
+use nom::{
+    IResult, Parser,
+    bytes::complete::take,
+    combinator::{all_consuming, map},
+    error::{ContextError, ParseError, context},
+};
+use tokio::sync::watch;
+
+use crate::{
+    api::device,
+    devices::soundcore::{
+        a3959,
+        a3968::state::A3968State,
+        common::{
+            modules::ModuleCollection,
+            packet::{
+                self, Command,
+                inbound::{FromPacketBody, TryToPacket},
+                outbound::ToPacket,
+            },
+            packet_manager::PacketHandler,
+            structures::{DualBattery, DualFirmwareVersion, SerialNumber},
+        },
+    },
+};
+
+/// State update packet for the Soundcore Sport X20 (A3968).
+///
+/// Body is 143 bytes. Confirmed layout:
+///   0..2     tws status (host earbud, both-connected)
+///   2..6     dual battery (left level, right level, left charging, right charging)
+///   6..16    dual firmware version (left "01.65", right "01.65")
+///   16..32   serial number (16 ASCII chars; "3968" + mac)
+///   32..117  equalizer (preset id + 8 bands at offset 38, 120 = 0.0 dB) + right-channel /
+///            HearID data + reserved. Left unparsed for now: the X20 ignores every standard
+///            EQ "set" command, so EQ is deferred to a follow-up once that's reverse-engineered.
+///   117..124 sound-mode block (A3959 format: ambient sound mode at offset 117)
+///   124..143 reserved
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct A3968StateUpdatePacket {
+    pub dual_battery: DualBattery,
+    pub dual_firmware_version: DualFirmwareVersion,
+    pub serial_number: SerialNumber,
+    pub sound_modes: a3959::structures::SoundModes,
+}
+
+impl FromPacketBody for A3968StateUpdatePacket {
+    type DirectionMarker = packet::InboundMarker;
+
+    fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context(
+            "a3968 state update packet",
+            all_consuming(map(
+                (
+                    take(2usize),                        // tws status (host, both-connected)
+                    DualBattery::take,                   // 4 bytes
+                    DualFirmwareVersion::take,           // 10 bytes
+                    SerialNumber::take,                  // 16 bytes
+                    take(85usize), // equalizer + HearID + reserved (offsets 32..117)
+                    a3959::structures::SoundModes::take, // sound-mode block (offsets 117..124)
+                    take(19usize), // reserved (offsets 124..143)
+                ),
+                |(
+                    _tws,
+                    dual_battery,
+                    dual_firmware_version,
+                    serial_number,
+                    _eq_and_reserved,
+                    mut sound_modes,
+                    _reserved,
+                )| {
+                    // The device reports a live adaptive-sensitivity byte (255) and wind flags
+                    // that are invalid as inputs and make the X20 reject NoiseCanceling on set.
+                    // Normalize them so the set path always emits clean, accepted values.
+                    sound_modes.noise_canceling_adaptive_sensitivity_level = 0;
+                    sound_modes.wind_noise.is_suppression_enabled = false;
+                    sound_modes.wind_noise.is_detected = false;
+                    Self {
+                        dual_battery,
+                        dual_firmware_version,
+                        serial_number,
+                        sound_modes,
+                    }
+                },
+            )),
+        )
+        .parse_complete(input)
+    }
+}
+
+impl ToPacket for A3968StateUpdatePacket {
+    type DirectionMarker = packet::InboundMarker;
+
+    fn command(&self) -> Command {
+        packet::inbound::STATE_COMMAND
+    }
+
+    fn body(&self) -> Vec<u8> {
+        [0u8, 0u8] // tws status
+            .into_iter()
+            .chain(self.dual_battery.bytes())
+            .chain(self.dual_firmware_version.bytes())
+            .chain(self.serial_number.bytes())
+            .chain(std::iter::repeat_n(0u8, 85))
+            .chain(self.sound_modes.bytes())
+            .chain(std::iter::repeat_n(0u8, 19))
+            .collect()
+    }
+}
+
+struct StateUpdatePacketHandler;
+
+#[async_trait]
+impl PacketHandler<A3968State> for StateUpdatePacketHandler {
+    async fn handle_packet(
+        &self,
+        state: &watch::Sender<A3968State>,
+        packet: &packet::Inbound,
+    ) -> device::Result<()> {
+        let packet: A3968StateUpdatePacket = packet.try_to_packet()?;
+        state.send_modify(|state| *state = packet.into());
+        Ok(())
+    }
+}
+
+impl ModuleCollection<A3968State> {
+    pub fn add_state_update(&mut self) {
+        self.packet_handlers.set_handler(
+            packet::inbound::STATE_COMMAND,
+            Box::new(StateUpdatePacketHandler {}),
+        );
+    }
+}

--- a/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/a3968/packets/inbound/state_update.rs
@@ -20,7 +20,7 @@ use crate::{
                 outbound::ToPacket,
             },
             packet_manager::PacketHandler,
-            structures::{DualBattery, DualFirmwareVersion, SerialNumber},
+            structures::{DualBattery, DualFirmwareVersion, SerialNumber, TwsStatus},
         },
     },
 };
@@ -39,6 +39,7 @@ use crate::{
 ///   124..143 reserved
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct A3968StateUpdatePacket {
+    pub tws_status: TwsStatus,
     pub dual_battery: DualBattery,
     pub dual_firmware_version: DualFirmwareVersion,
     pub serial_number: SerialNumber,
@@ -55,7 +56,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
             "a3968 state update packet",
             all_consuming(map(
                 (
-                    take(2usize),                        // tws status (host, both-connected)
+                    TwsStatus::take,                     // tws status (host, both-connected)
                     DualBattery::take,                   // 4 bytes
                     DualFirmwareVersion::take,           // 10 bytes
                     SerialNumber::take,                  // 16 bytes
@@ -64,7 +65,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     take(19usize), // reserved (offsets 124..143)
                 ),
                 |(
-                    _tws,
+                    tws_status,
                     dual_battery,
                     dual_firmware_version,
                     serial_number,
@@ -79,6 +80,7 @@ impl FromPacketBody for A3968StateUpdatePacket {
                     sound_modes.wind_noise.is_suppression_enabled = false;
                     sound_modes.wind_noise.is_detected = false;
                     Self {
+                        tws_status,
                         dual_battery,
                         dual_firmware_version,
                         serial_number,
@@ -99,7 +101,8 @@ impl ToPacket for A3968StateUpdatePacket {
     }
 
     fn body(&self) -> Vec<u8> {
-        [0u8, 0u8] // tws status
+        self.tws_status
+            .bytes()
             .into_iter()
             .chain(self.dual_battery.bytes())
             .chain(self.dual_firmware_version.bytes())

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -4,10 +4,11 @@ use crate::devices::soundcore::{
     a3968,
     common::{
         modules::reset_button_configuration::ResetButtonConfigurationPending,
+        state::Update,
         structures::{
-            AgeRange, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
-            DualFirmwareVersion, Gender, SerialNumber, TwsStatus,
-            button_configuration::ButtonStatusCollection,
+            AgeRange, AutoPowerOff, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId,
+            DualBattery, DualConnections, DualConnectionsDevice, DualFirmwareVersion, Gender,
+            SerialNumber, TouchTone, TwsStatus, button_configuration::ButtonStatusCollection,
         },
     },
 };
@@ -25,26 +26,69 @@ pub struct A3968State {
     equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
     hear_id: CustomHearId<2, 10>,
     button_configuration: ButtonStatusCollection<6>,
+    dual_connections: DualConnections,
+    touch_tone: TouchTone,
+    auto_power_off: AutoPowerOff,
     age_range: AgeRange,
     gender: Gender,
     button_reset_pending: ResetButtonConfigurationPending,
 }
 
-impl From<A3968StateUpdatePacket> for A3968State {
-    fn from(value: A3968StateUpdatePacket) -> Self {
+impl A3968State {
+    pub fn new(
+        packet: a3968::packets::inbound::A3968StateUpdatePacket,
+        dual_connections_devices: Vec<DualConnectionsDevice>,
+    ) -> Self {
         Self {
-            tws_status: value.tws_status,
-            dual_battery: value.dual_battery,
-            dual_firmware_version: value.dual_firmware_version,
-            serial_number: value.serial_number,
-            case_battery_level: value.case_battery_level,
-            equalizer_configuration: value.equalizer_configuration,
-            hear_id: value.hear_id,
-            sound_modes: value.sound_modes,
-            button_configuration: value.button_configuration,
+            tws_status: packet.tws_status,
+            dual_battery: packet.dual_battery,
+            dual_firmware_version: packet.dual_firmware_version,
+            serial_number: packet.serial_number,
+            case_battery_level: packet.case_battery_level,
+            sound_modes: packet.sound_modes,
+            equalizer_configuration: packet.equalizer_configuration,
+            hear_id: packet.hear_id,
+            button_configuration: packet.button_configuration,
+            dual_connections: DualConnections {
+                is_enabled: packet.dual_connections_enabled,
+                devices: dual_connections_devices,
+            },
+            touch_tone: packet.touch_tone,
+            auto_power_off: packet.auto_power_off,
             age_range: AgeRange::default(),
             gender: Gender::default(),
             button_reset_pending: ResetButtonConfigurationPending::default(),
         }
+    }
+}
+
+impl Update<A3968StateUpdatePacket> for A3968State {
+    fn update(&mut self, partial: A3968StateUpdatePacket) {
+        let A3968StateUpdatePacket {
+            tws_status,
+            dual_battery,
+            dual_firmware_version,
+            serial_number,
+            case_battery_level,
+            equalizer_configuration,
+            hear_id,
+            button_configuration,
+            sound_modes,
+            dual_connections_enabled,
+            touch_tone,
+            auto_power_off,
+        } = partial;
+        self.tws_status = tws_status;
+        self.dual_battery = dual_battery;
+        self.dual_firmware_version = dual_firmware_version;
+        self.serial_number = serial_number;
+        self.case_battery_level = case_battery_level;
+        self.equalizer_configuration = equalizer_configuration;
+        self.hear_id = hear_id;
+        self.button_configuration = button_configuration;
+        self.sound_modes = sound_modes;
+        self.dual_connections.is_enabled = dual_connections_enabled;
+        self.touch_tone = touch_tone;
+        self.auto_power_off = auto_power_off;
     }
 }

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -1,0 +1,28 @@
+use openscq30_lib_macros::Has;
+
+use crate::devices::soundcore::{
+    a3959,
+    common::structures::{DualBattery, DualFirmwareVersion, SerialNumber},
+};
+
+use super::packets::inbound::A3968StateUpdatePacket;
+
+#[derive(Debug, Clone, PartialEq, Eq, Has)]
+pub struct A3968State {
+    pub dual_battery: DualBattery,
+    pub dual_firmware_version: DualFirmwareVersion,
+    pub serial_number: SerialNumber,
+    // The X20 uses the same sound-mode structure as the A3959 (P30i).
+    pub sound_modes: a3959::structures::SoundModes,
+}
+
+impl From<A3968StateUpdatePacket> for A3968State {
+    fn from(value: A3968StateUpdatePacket) -> Self {
+        Self {
+            dual_battery: value.dual_battery,
+            dual_firmware_version: value.dual_firmware_version,
+            serial_number: value.serial_number,
+            sound_modes: value.sound_modes,
+        }
+    }
+}

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -2,18 +2,25 @@ use openscq30_lib_macros::Has;
 
 use crate::devices::soundcore::{
     a3968,
-    common::structures::{DualBattery, DualFirmwareVersion, SerialNumber, TwsStatus},
+    common::structures::{
+        AgeRange, CommonEqualizerConfiguration, CustomHearId, DualBattery, DualFirmwareVersion,
+        Gender, SerialNumber, TwsStatus,
+    },
 };
 
 use super::packets::inbound::A3968StateUpdatePacket;
 
 #[derive(Debug, Clone, PartialEq, Eq, Has)]
 pub struct A3968State {
-    pub tws_status: TwsStatus,
-    pub dual_battery: DualBattery,
-    pub dual_firmware_version: DualFirmwareVersion,
-    pub serial_number: SerialNumber,
-    pub sound_modes: a3968::structures::SoundModes,
+    tws_status: TwsStatus,
+    dual_battery: DualBattery,
+    dual_firmware_version: DualFirmwareVersion,
+    serial_number: SerialNumber,
+    sound_modes: a3968::structures::SoundModes,
+    equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
+    hear_id: CustomHearId<2, 10>,
+    age_range: AgeRange,
+    gender: Gender,
 }
 
 impl From<A3968StateUpdatePacket> for A3968State {
@@ -23,7 +30,11 @@ impl From<A3968StateUpdatePacket> for A3968State {
             dual_battery: value.dual_battery,
             dual_firmware_version: value.dual_firmware_version,
             serial_number: value.serial_number,
+            equalizer_configuration: value.equalizer_configuration,
+            hear_id: value.hear_id,
             sound_modes: value.sound_modes,
+            age_range: AgeRange::default(),
+            gender: Gender::default(),
         }
     }
 }

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -2,13 +2,14 @@ use openscq30_lib_macros::Has;
 
 use crate::devices::soundcore::{
     a3959,
-    common::structures::{DualBattery, DualFirmwareVersion, SerialNumber},
+    common::structures::{DualBattery, DualFirmwareVersion, SerialNumber, TwsStatus},
 };
 
 use super::packets::inbound::A3968StateUpdatePacket;
 
 #[derive(Debug, Clone, PartialEq, Eq, Has)]
 pub struct A3968State {
+    pub tws_status: TwsStatus,
     pub dual_battery: DualBattery,
     pub dual_firmware_version: DualFirmwareVersion,
     pub serial_number: SerialNumber,
@@ -19,6 +20,7 @@ pub struct A3968State {
 impl From<A3968StateUpdatePacket> for A3968State {
     fn from(value: A3968StateUpdatePacket) -> Self {
         Self {
+            tws_status: value.tws_status,
             dual_battery: value.dual_battery,
             dual_firmware_version: value.dual_firmware_version,
             serial_number: value.serial_number,

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -2,9 +2,13 @@ use openscq30_lib_macros::Has;
 
 use crate::devices::soundcore::{
     a3968,
-    common::structures::{
-        AgeRange, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
-        DualFirmwareVersion, Gender, SerialNumber, TwsStatus,
+    common::{
+        modules::reset_button_configuration::ResetButtonConfigurationPending,
+        structures::{
+            AgeRange, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
+            DualFirmwareVersion, Gender, SerialNumber, TwsStatus,
+            button_configuration::ButtonStatusCollection,
+        },
     },
 };
 
@@ -20,8 +24,10 @@ pub struct A3968State {
     sound_modes: a3968::structures::SoundModes,
     equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
     hear_id: CustomHearId<2, 10>,
+    button_configuration: ButtonStatusCollection<6>,
     age_range: AgeRange,
     gender: Gender,
+    button_reset_pending: ResetButtonConfigurationPending,
 }
 
 impl From<A3968StateUpdatePacket> for A3968State {
@@ -35,8 +41,10 @@ impl From<A3968StateUpdatePacket> for A3968State {
             equalizer_configuration: value.equalizer_configuration,
             hear_id: value.hear_id,
             sound_modes: value.sound_modes,
+            button_configuration: value.button_configuration,
             age_range: AgeRange::default(),
             gender: Gender::default(),
+            button_reset_pending: ResetButtonConfigurationPending::default(),
         }
     }
 }

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -3,8 +3,8 @@ use openscq30_lib_macros::Has;
 use crate::devices::soundcore::{
     a3968,
     common::structures::{
-        AgeRange, CommonEqualizerConfiguration, CustomHearId, DualBattery, DualFirmwareVersion,
-        Gender, SerialNumber, TwsStatus,
+        AgeRange, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId, DualBattery,
+        DualFirmwareVersion, Gender, SerialNumber, TwsStatus,
     },
 };
 
@@ -16,6 +16,7 @@ pub struct A3968State {
     dual_battery: DualBattery,
     dual_firmware_version: DualFirmwareVersion,
     serial_number: SerialNumber,
+    case_battery_level: CaseBatteryLevel,
     sound_modes: a3968::structures::SoundModes,
     equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
     hear_id: CustomHearId<2, 10>,
@@ -30,6 +31,7 @@ impl From<A3968StateUpdatePacket> for A3968State {
             dual_battery: value.dual_battery,
             dual_firmware_version: value.dual_firmware_version,
             serial_number: value.serial_number,
+            case_battery_level: value.case_battery_level,
             equalizer_configuration: value.equalizer_configuration,
             hear_id: value.hear_id,
             sound_modes: value.sound_modes,

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -6,9 +6,10 @@ use crate::devices::soundcore::{
         modules::reset_button_configuration::ResetButtonConfigurationPending,
         state::Update,
         structures::{
-            AgeRange, AutoPowerOff, CaseBatteryLevel, CommonEqualizerConfiguration, CustomHearId,
-            DualBattery, DualConnections, DualConnectionsDevice, DualFirmwareVersion, Gender,
-            SerialNumber, TouchTone, TwsStatus, button_configuration::ButtonStatusCollection,
+            AgeRange, AmbientSoundModeCycleTws, AutoPowerOff, CaseBatteryLevel,
+            CommonEqualizerConfiguration, CustomHearId, DualBattery, DualConnections,
+            DualConnectionsDevice, DualFirmwareVersion, Gender, SerialNumber, TouchTone, TwsStatus,
+            button_configuration::ButtonStatusCollection,
         },
     },
 };
@@ -26,6 +27,7 @@ pub struct A3968State {
     equalizer_configuration: CommonEqualizerConfiguration<2, 10>,
     hear_id: CustomHearId<2, 10>,
     button_configuration: ButtonStatusCollection<6>,
+    ambient_sound_mode_cycle: AmbientSoundModeCycleTws,
     dual_connections: DualConnections,
     touch_tone: TouchTone,
     auto_power_off: AutoPowerOff,
@@ -49,6 +51,7 @@ impl A3968State {
             equalizer_configuration: packet.equalizer_configuration,
             hear_id: packet.hear_id,
             button_configuration: packet.button_configuration,
+            ambient_sound_mode_cycle: packet.ambient_sound_mode_cycle,
             dual_connections: DualConnections {
                 is_enabled: packet.dual_connections_enabled,
                 devices: dual_connections_devices,
@@ -77,6 +80,7 @@ impl Update<A3968StateUpdatePacket> for A3968State {
             dual_connections_enabled,
             touch_tone,
             auto_power_off,
+            ambient_sound_mode_cycle,
         } = partial;
         self.tws_status = tws_status;
         self.dual_battery = dual_battery;
@@ -90,5 +94,6 @@ impl Update<A3968StateUpdatePacket> for A3968State {
         self.dual_connections.is_enabled = dual_connections_enabled;
         self.touch_tone = touch_tone;
         self.auto_power_off = auto_power_off;
+        self.ambient_sound_mode_cycle = ambient_sound_mode_cycle;
     }
 }

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -1,7 +1,7 @@
 use openscq30_lib_macros::Has;
 
 use crate::devices::soundcore::{
-    a3959,
+    a3968,
     common::structures::{DualBattery, DualFirmwareVersion, SerialNumber, TwsStatus},
 };
 
@@ -13,8 +13,7 @@ pub struct A3968State {
     pub dual_battery: DualBattery,
     pub dual_firmware_version: DualFirmwareVersion,
     pub serial_number: SerialNumber,
-    // The X20 uses the same sound-mode structure as the A3959 (P30i).
-    pub sound_modes: a3959::structures::SoundModes,
+    pub sound_modes: a3968::structures::SoundModes,
 }
 
 impl From<A3968StateUpdatePacket> for A3968State {

--- a/lib/src/devices/soundcore/a3968/state.rs
+++ b/lib/src/devices/soundcore/a3968/state.rs
@@ -8,8 +8,8 @@ use crate::devices::soundcore::{
         structures::{
             AgeRange, AmbientSoundModeCycleTws, AutoPowerOff, CaseBatteryLevel,
             CommonEqualizerConfiguration, CustomHearId, DualBattery, DualConnections,
-            DualConnectionsDevice, DualFirmwareVersion, Gender, SerialNumber, TouchTone, TwsStatus,
-            button_configuration::ButtonStatusCollection,
+            DualConnectionsDevice, DualFirmwareVersion, Gender, SerialNumber, SurroundSound,
+            TouchTone, TwsStatus, button_configuration::ButtonStatusCollection,
         },
     },
 };
@@ -31,6 +31,7 @@ pub struct A3968State {
     dual_connections: DualConnections,
     touch_tone: TouchTone,
     auto_power_off: AutoPowerOff,
+    surround_sound: SurroundSound,
     age_range: AgeRange,
     gender: Gender,
     button_reset_pending: ResetButtonConfigurationPending,
@@ -58,6 +59,7 @@ impl A3968State {
             },
             touch_tone: packet.touch_tone,
             auto_power_off: packet.auto_power_off,
+            surround_sound: packet.surround_sound,
             age_range: AgeRange::default(),
             gender: Gender::default(),
             button_reset_pending: ResetButtonConfigurationPending::default(),
@@ -81,6 +83,7 @@ impl Update<A3968StateUpdatePacket> for A3968State {
             touch_tone,
             auto_power_off,
             ambient_sound_mode_cycle,
+            surround_sound,
         } = partial;
         self.tws_status = tws_status;
         self.dual_battery = dual_battery;
@@ -95,5 +98,6 @@ impl Update<A3968StateUpdatePacket> for A3968State {
         self.touch_tone = touch_tone;
         self.auto_power_off = auto_power_off;
         self.ambient_sound_mode_cycle = ambient_sound_mode_cycle;
+        self.surround_sound = surround_sound;
     }
 }

--- a/lib/src/devices/soundcore/a3968/structures.rs
+++ b/lib/src/devices/soundcore/a3968/structures.rs
@@ -1,0 +1,3 @@
+mod sound_modes;
+
+pub use sound_modes::*;

--- a/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
@@ -5,7 +5,6 @@ use nom::{
     number::complete::le_u8,
 };
 use openscq30_i18n_macros::Translate;
-use openscq30_lib_macros::MigrationSteps;
 use strum::{Display, EnumIter, EnumString, FromRepr, IntoStaticStr, VariantArray};
 
 use crate::devices::soundcore::common::{
@@ -15,22 +14,13 @@ use crate::devices::soundcore::common::{
     structures::TransparencyMode,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, MigrationSteps)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct SoundModes {
     pub ambient_sound_mode: common::structures::AmbientSoundMode,
-    #[migration_requirement(field = ambient_sound_mode, value = common::structures::AmbientSoundMode::NoiseCanceling)]
     pub noise_canceling_mode: NoiseCancelingMode,
-    #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::Adaptive)]
     pub adaptive_noise_canceling: AdaptiveNoiseCanceling,
-    #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::Manual)]
     pub manual_noise_canceling: ManualNoiseCanceling,
-    #[migration_requirement(field = ambient_sound_mode, value = common::structures::AmbientSoundMode::Transparency)]
     pub transparency_mode: TransparencyMode,
-    #[migration_requirement(
-        field = ambient_sound_mode,
-        value = common::structures::AmbientSoundMode::NoiseCanceling,
-        value2 = common::structures::AmbientSoundMode::Transparency,
-    )]
     pub wind_noise: WindNoise,
 }
 

--- a/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
@@ -1,0 +1,210 @@
+use nom::{
+    IResult, Parser,
+    combinator::map,
+    error::{ContextError, ParseError, context},
+    number::complete::le_u8,
+};
+use openscq30_i18n_macros::Translate;
+use openscq30_lib_macros::MigrationSteps;
+use strum::{Display, EnumIter, EnumString, FromRepr, IntoStaticStr, VariantArray};
+
+use crate::devices::soundcore::common::{
+    self,
+    modules::sound_modes_v2,
+    packet::{self, inbound::FromPacketBody},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, MigrationSteps)]
+pub struct SoundModes {
+    pub ambient_sound_mode: common::structures::AmbientSoundMode,
+    #[migration_requirement(field = ambient_sound_mode, value = common::structures::AmbientSoundMode::NoiseCanceling)]
+    pub noise_canceling_mode: NoiseCancelingMode,
+    #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::Adaptive)]
+    pub adaptive_noise_canceling: AdaptiveNoiseCanceling,
+    #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::Manual)]
+    pub manual_noise_canceling: ManualNoiseCanceling,
+    #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::MultiScene)]
+    pub multi_scene_anc: common::structures::NoiseCancelingMode,
+    #[migration_requirement(
+        field = ambient_sound_mode,
+        value = common::structures::AmbientSoundMode::NoiseCanceling,
+        value2 = common::structures::AmbientSoundMode::Transparency,
+    )]
+    pub wind_noise: WindNoise,
+    pub noise_canceling_adaptive_sensitivity_level: u8,
+}
+
+impl SoundModes {
+    pub fn bytes(&self) -> [u8; 7] {
+        [
+            self.ambient_sound_mode.id(),
+            (self.manual_noise_canceling.0 << 4) | self.adaptive_noise_canceling.inner(),
+            self.ambient_sound_mode.id(),
+            self.noise_canceling_mode.id(), // ANC automation mode?
+            self.wind_noise.byte(),
+            self.noise_canceling_adaptive_sensitivity_level,
+            self.multi_scene_anc.id(),
+        ]
+    }
+}
+
+impl FromPacketBody for SoundModes {
+    type DirectionMarker = packet::InboundMarker;
+
+    fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context(
+            "a3968 sound modes",
+            map(
+                (
+                    common::structures::AmbientSoundMode::take,
+                    NoiseCancelingSettings::take,
+                    common::structures::AmbientSoundMode::take,
+                    NoiseCancelingMode::take,
+                    WindNoise::take,
+                    le_u8,
+                    common::structures::NoiseCancelingMode::take,
+                ),
+                |(
+                    ambient_sound_mode,
+                    noise_canceling_settings,
+                    _ambient_sound_mode,
+                    noise_canceling_mode,
+                    wind_noise,
+                    noise_canceling_adaptive_sensitivity_level,
+                    multi_scene_anc,
+                )| {
+                    Self {
+                        ambient_sound_mode,
+                        adaptive_noise_canceling: noise_canceling_settings.adaptive,
+                        manual_noise_canceling: noise_canceling_settings.manual,
+                        noise_canceling_mode,
+                        wind_noise,
+                        noise_canceling_adaptive_sensitivity_level,
+                        multi_scene_anc,
+                    }
+                },
+            ),
+        )
+        .parse_complete(input)
+    }
+}
+
+impl sound_modes_v2::ToPacketBody for SoundModes {
+    fn bytes(&self) -> Vec<u8> {
+        self.bytes().to_vec()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
+pub struct AdaptiveNoiseCanceling(u8);
+
+impl AdaptiveNoiseCanceling {
+    pub fn new(value: u8) -> Self {
+        Self(value.clamp(1, 5))
+    }
+
+    pub fn inner(&self) -> u8 {
+        self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
+pub struct ManualNoiseCanceling(u8);
+
+impl ManualNoiseCanceling {
+    pub fn new(value: u8) -> Self {
+        Self(value.clamp(1, 5))
+    }
+
+    pub fn inner(&self) -> u8 {
+        self.0
+    }
+}
+
+struct NoiseCancelingSettings {
+    manual: ManualNoiseCanceling,
+    adaptive: AdaptiveNoiseCanceling,
+}
+
+impl NoiseCancelingSettings {
+    fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        map(le_u8, |b| Self {
+            manual: ManualNoiseCanceling::new((b & 0xF0) >> 4),
+            adaptive: AdaptiveNoiseCanceling::new(b & 0x0F),
+        })
+        .parse_complete(input)
+    }
+}
+
+#[repr(u8)]
+#[derive(
+    FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Display,
+    Default,
+    IntoStaticStr,
+    EnumString,
+    EnumIter,
+    VariantArray,
+    Translate,
+)]
+pub enum NoiseCancelingMode {
+    #[default]
+    Manual = 0,
+    Adaptive = 1,
+    MultiScene = 2,
+}
+
+impl NoiseCancelingMode {
+    pub fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context(
+            "a3968 noise canceling mode",
+            map(le_u8, |noise_canceling_mode| {
+                Self::from_repr(noise_canceling_mode).unwrap_or_default()
+            }),
+        )
+        .parse_complete(input)
+    }
+}
+
+impl NoiseCancelingMode {
+    pub fn id(&self) -> u8 {
+        *self as u8
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct WindNoise {
+    pub is_suppression_enabled: bool,
+    pub is_detected: bool,
+}
+
+impl WindNoise {
+    pub fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context(
+            "wind noise",
+            map(le_u8, |wind_noise| Self {
+                is_suppression_enabled: wind_noise & 1 != 0,
+                is_detected: wind_noise & 2 != 0,
+            }),
+        )
+        .parse_complete(input)
+    }
+
+    pub fn byte(&self) -> u8 {
+        u8::from(self.is_suppression_enabled) | (u8::from(self.is_detected) << 1)
+    }
+}

--- a/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
@@ -31,7 +31,6 @@ pub struct SoundModes {
         value2 = common::structures::AmbientSoundMode::Transparency,
     )]
     pub wind_noise: WindNoise,
-    pub noise_canceling_adaptive_sensitivity_level: u8,
 }
 
 impl SoundModes {
@@ -42,7 +41,7 @@ impl SoundModes {
             self.ambient_sound_mode.id(),
             self.noise_canceling_mode.id(), // ANC automation mode?
             self.wind_noise.byte(),
-            self.noise_canceling_adaptive_sensitivity_level,
+            0, // unknown
             self.multi_scene_anc.id(),
         ]
     }
@@ -72,7 +71,7 @@ impl FromPacketBody for SoundModes {
                     _ambient_sound_mode,
                     noise_canceling_mode,
                     wind_noise,
-                    noise_canceling_adaptive_sensitivity_level,
+                    _unknown,
                     multi_scene_anc,
                 )| {
                     Self {
@@ -81,7 +80,6 @@ impl FromPacketBody for SoundModes {
                         manual_noise_canceling: noise_canceling_settings.manual,
                         noise_canceling_mode,
                         wind_noise,
-                        noise_canceling_adaptive_sensitivity_level,
                         multi_scene_anc,
                     }
                 },

--- a/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
+++ b/lib/src/devices/soundcore/a3968/structures/sound_modes.rs
@@ -12,6 +12,7 @@ use crate::devices::soundcore::common::{
     self,
     modules::sound_modes_v2,
     packet::{self, inbound::FromPacketBody},
+    structures::TransparencyMode,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, MigrationSteps)]
@@ -23,8 +24,8 @@ pub struct SoundModes {
     pub adaptive_noise_canceling: AdaptiveNoiseCanceling,
     #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::Manual)]
     pub manual_noise_canceling: ManualNoiseCanceling,
-    #[migration_requirement(field = noise_canceling_mode, value = NoiseCancelingMode::MultiScene)]
-    pub multi_scene_anc: common::structures::NoiseCancelingMode,
+    #[migration_requirement(field = ambient_sound_mode, value = common::structures::AmbientSoundMode::Transparency)]
+    pub transparency_mode: TransparencyMode,
     #[migration_requirement(
         field = ambient_sound_mode,
         value = common::structures::AmbientSoundMode::NoiseCanceling,
@@ -34,15 +35,14 @@ pub struct SoundModes {
 }
 
 impl SoundModes {
-    pub fn bytes(&self) -> [u8; 7] {
+    pub fn bytes(&self) -> [u8; 6] {
         [
             self.ambient_sound_mode.id(),
-            (self.manual_noise_canceling.0 << 4) | self.adaptive_noise_canceling.inner(),
-            self.ambient_sound_mode.id(),
-            self.noise_canceling_mode.id(), // ANC automation mode?
+            ((self.manual_noise_canceling as u8) << 4) | self.adaptive_noise_canceling as u8,
+            self.transparency_mode.id(),
+            self.noise_canceling_mode.id(),
             self.wind_noise.byte(),
-            0, // unknown
-            self.multi_scene_anc.id(),
+            0xFF, // unknown
         ]
     }
 }
@@ -59,28 +59,26 @@ impl FromPacketBody for SoundModes {
                 (
                     common::structures::AmbientSoundMode::take,
                     NoiseCancelingSettings::take,
-                    common::structures::AmbientSoundMode::take,
+                    common::structures::TransparencyMode::take,
                     NoiseCancelingMode::take,
                     WindNoise::take,
                     le_u8,
-                    common::structures::NoiseCancelingMode::take,
                 ),
                 |(
                     ambient_sound_mode,
                     noise_canceling_settings,
-                    _ambient_sound_mode,
+                    transparency_mode,
                     noise_canceling_mode,
                     wind_noise,
                     _unknown,
-                    multi_scene_anc,
                 )| {
                     Self {
                         ambient_sound_mode,
                         adaptive_noise_canceling: noise_canceling_settings.adaptive,
                         manual_noise_canceling: noise_canceling_settings.manual,
                         noise_canceling_mode,
+                        transparency_mode,
                         wind_noise,
-                        multi_scene_anc,
                     }
                 },
             ),
@@ -95,29 +93,56 @@ impl sound_modes_v2::ToPacketBody for SoundModes {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
-pub struct AdaptiveNoiseCanceling(u8);
-
-impl AdaptiveNoiseCanceling {
-    pub fn new(value: u8) -> Self {
-        Self(value.clamp(1, 5))
-    }
-
-    pub fn inner(&self) -> u8 {
-        self.0
-    }
+#[repr(u8)]
+#[derive(
+    FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Display,
+    Default,
+    IntoStaticStr,
+    EnumString,
+    EnumIter,
+    Translate,
+)]
+#[allow(clippy::enum_variant_names)]
+pub enum AdaptiveNoiseCanceling {
+    #[default]
+    LowNoise = 0,
+    MediumNoise = 1,
+    HighNoise = 2,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, PartialOrd, Ord)]
-pub struct ManualNoiseCanceling(u8);
+#[repr(u8)]
+#[derive(
+    FromRepr,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    Display,
+    Default,
+    IntoStaticStr,
+    EnumString,
+    EnumIter,
+    Translate,
+)]
+pub enum ManualNoiseCanceling {
+    #[default]
+    Weak = 1,
+    Moderate = 2,
+    Strong = 3,
+}
 
 impl ManualNoiseCanceling {
-    pub fn new(value: u8) -> Self {
-        Self(value.clamp(1, 5))
-    }
-
-    pub fn inner(&self) -> u8 {
-        self.0
+    pub fn id(&self) -> u8 {
+        *self as u8
     }
 }
 
@@ -131,8 +156,8 @@ impl NoiseCancelingSettings {
         input: &'a [u8],
     ) -> IResult<&'a [u8], Self, E> {
         map(le_u8, |b| Self {
-            manual: ManualNoiseCanceling::new((b & 0xF0) >> 4),
-            adaptive: AdaptiveNoiseCanceling::new(b & 0x0F),
+            manual: ManualNoiseCanceling::from_repr((b & 0xF0) >> 4).unwrap_or_default(),
+            adaptive: AdaptiveNoiseCanceling::from_repr(b & 0x0F).unwrap_or_default(),
         })
         .parse_complete(input)
     }
@@ -159,7 +184,6 @@ pub enum NoiseCancelingMode {
     #[default]
     Manual = 0,
     Adaptive = 1,
-    MultiScene = 2,
 }
 
 impl NoiseCancelingMode {

--- a/lib/src/devices/soundcore/common/device.rs
+++ b/lib/src/devices/soundcore/common/device.rs
@@ -28,10 +28,11 @@ use crate::{
                 packet::{self, PacketIOController, outbound::ToPacket},
                 state::Update,
                 structures::{
-                    AutoPlayPause, AutoPowerOff, BatteryLevel, CaseBatteryLevel, DualConnections,
-                    EqualizerConfiguration, GamingMode, Ldac, LimitHighVolume, LowBatteryPrompt,
-                    SoundLeakCompensation, SurroundSound, TouchLock, TouchTone, VoicePrompt,
-                    WearingDetection, WearingTone, button_configuration::ButtonStatusCollection,
+                    AmbientSoundModeCycleTws, AutoPlayPause, AutoPowerOff, BatteryLevel,
+                    CaseBatteryLevel, DualConnections, EqualizerConfiguration, GamingMode, Ldac,
+                    LimitHighVolume, LowBatteryPrompt, SoundLeakCompensation, SurroundSound,
+                    TouchLock, TouchTone, VoicePrompt, WearingDetection, WearingTone,
+                    button_configuration::ButtonStatusCollection,
                 },
             },
         },
@@ -525,6 +526,15 @@ where
     {
         self.module_collection
             .add_ambient_sound_mode_cycle(self.packet_io_controller.clone());
+    }
+
+    pub fn ambient_sound_mode_cycle_tws(&mut self)
+    where
+        StateType:
+            Has<TwsStatus> + Has<AmbientSoundModeCycleTws> + Has<ResetButtonConfigurationPending>,
+    {
+        self.module_collection
+            .add_ambient_sound_mode_cycle_tws(self.packet_io_controller.clone());
     }
 
     pub fn reset_button_configuration<ButtonConfigurationPacketType>(

--- a/lib/src/devices/soundcore/common/modules.rs
+++ b/lib/src/devices/soundcore/common/modules.rs
@@ -20,6 +20,7 @@ use super::{
 };
 
 pub mod ambient_sound_mode_cycle;
+mod ambient_sound_mode_cycle_tws;
 pub mod auto_power_off;
 pub mod button_configuration;
 pub mod case_battery_level;

--- a/lib/src/devices/soundcore/common/modules/ambient_sound_mode_cycle_tws.rs
+++ b/lib/src/devices/soundcore/common/modules/ambient_sound_mode_cycle_tws.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use openscq30_lib_has::Has;
+use setting_handler::AmbientSoundModeCycleTwsSettingHandler;
+use state_modifier::AmbientSoundModeCycleTwsStateModifier;
+use strum::{EnumIter, EnumString};
+
+use crate::{
+    api::settings::{CategoryId, SettingId},
+    devices::soundcore::common::{
+        modules::reset_button_configuration::ResetButtonConfigurationPending,
+        packet::PacketIOController,
+        structures::{AmbientSoundModeCycleTws, TwsStatus},
+    },
+    macros::enum_subset,
+};
+
+use super::ModuleCollection;
+
+mod setting_handler;
+mod state_modifier;
+
+enum_subset!(
+    SettingId,
+    #[derive(EnumIter, EnumString)]
+    #[allow(clippy::enum_variant_names)]
+    enum SoundModeCycleSetting {
+        NormalModeInCycle,
+        TransparencyModeInCycle,
+        NoiseCancelingModeInCycle,
+    }
+);
+
+impl<T> ModuleCollection<T>
+where
+    T: Has<TwsStatus>
+        + Has<AmbientSoundModeCycleTws>
+        + Has<ResetButtonConfigurationPending>
+        + Clone
+        + Send
+        + Sync,
+{
+    pub fn add_ambient_sound_mode_cycle_tws(&mut self, packet_io: Arc<PacketIOController>) {
+        self.setting_manager.add_handler(
+            CategoryId::ButtonConfiguration,
+            AmbientSoundModeCycleTwsSettingHandler,
+        );
+        self.state_modifiers
+            .push(Box::new(AmbientSoundModeCycleTwsStateModifier::new(
+                packet_io,
+            )));
+    }
+}

--- a/lib/src/devices/soundcore/common/modules/ambient_sound_mode_cycle_tws/setting_handler.rs
+++ b/lib/src/devices/soundcore/common/modules/ambient_sound_mode_cycle_tws/setting_handler.rs
@@ -1,0 +1,97 @@
+use async_trait::async_trait;
+use openscq30_lib_has::Has;
+use strum::IntoEnumIterator;
+
+use crate::{
+    api::settings::{Setting, SettingId, Value},
+    devices::soundcore::common::{
+        settings_manager::{SettingHandler, SettingHandlerResult},
+        structures::{AmbientSoundModeCycleTws, TwsStatus},
+    },
+};
+
+use super::SoundModeCycleSetting;
+
+pub struct AmbientSoundModeCycleTwsSettingHandler;
+
+#[async_trait]
+impl<T> SettingHandler<T> for AmbientSoundModeCycleTwsSettingHandler
+where
+    T: Has<TwsStatus> + Has<AmbientSoundModeCycleTws> + Send,
+{
+    fn settings(&self) -> Vec<SettingId> {
+        SoundModeCycleSetting::iter().map(Into::into).collect()
+    }
+
+    fn get(&self, state: &T, setting_id: &SettingId) -> Option<Setting> {
+        let cycle = state.get();
+        let tws_status: &TwsStatus = state.get();
+        get_inner(tws_status.is_connected, cycle, setting_id)
+    }
+
+    async fn set(
+        &self,
+        state: &mut T,
+        setting_id: &SettingId,
+        value: Value,
+    ) -> SettingHandlerResult<()> {
+        let tws_status: &TwsStatus = state.get();
+        let is_tws_connected = tws_status.is_connected;
+        let cycle = state.get_mut();
+        set_inner(is_tws_connected, cycle, setting_id, value)
+    }
+}
+
+#[inline(never)]
+fn get_inner(
+    is_tws_connected: bool,
+    tws_cycle: &AmbientSoundModeCycleTws,
+    setting_id: &SettingId,
+) -> Option<Setting> {
+    let setting: SoundModeCycleSetting = (*setting_id).try_into().ok()?;
+    let cycle = if is_tws_connected {
+        tws_cycle.tws_enabled
+    } else {
+        tws_cycle.tws_disabled
+    };
+    Some(match setting {
+        SoundModeCycleSetting::NormalModeInCycle => Setting::Toggle {
+            value: cycle.normal_mode,
+        },
+        SoundModeCycleSetting::TransparencyModeInCycle => Setting::Toggle {
+            value: cycle.transparency_mode,
+        },
+        SoundModeCycleSetting::NoiseCancelingModeInCycle => Setting::Toggle {
+            value: cycle.noise_canceling_mode,
+        },
+    })
+}
+
+#[inline(never)]
+fn set_inner(
+    is_tws_connected: bool,
+    tws_cycle: &mut AmbientSoundModeCycleTws,
+    setting_id: &SettingId,
+    value: Value,
+) -> SettingHandlerResult<()> {
+    let setting: SoundModeCycleSetting = (*setting_id)
+        .try_into()
+        .expect("already filtered to valid values only by SettingsManager");
+    let cycle = if is_tws_connected {
+        &mut tws_cycle.tws_enabled
+    } else {
+        &mut tws_cycle.tws_disabled
+    };
+    match setting {
+        SoundModeCycleSetting::NormalModeInCycle => {
+            cycle.normal_mode = value.try_as_bool()?;
+        }
+        SoundModeCycleSetting::TransparencyModeInCycle => {
+            cycle.transparency_mode = value.try_as_bool()?;
+        }
+        SoundModeCycleSetting::NoiseCancelingModeInCycle => {
+            cycle.noise_canceling_mode = value.try_as_bool()?;
+        }
+    }
+    Ok(())
+}

--- a/lib/src/devices/soundcore/common/modules/ambient_sound_mode_cycle_tws/state_modifier.rs
+++ b/lib/src/devices/soundcore/common/modules/ambient_sound_mode_cycle_tws/state_modifier.rs
@@ -1,0 +1,64 @@
+use async_trait::async_trait;
+use openscq30_lib_has::Has;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+use crate::{
+    api::device,
+    devices::soundcore::common::{
+        modules::reset_button_configuration::ResetButtonConfigurationPending,
+        packet::{self, PacketIOController},
+        state_modifier::StateModifier,
+        structures::{AmbientSoundModeCycleTws, TwsStatus},
+    },
+};
+
+pub struct AmbientSoundModeCycleTwsStateModifier {
+    packet_io: Arc<PacketIOController>,
+}
+
+impl AmbientSoundModeCycleTwsStateModifier {
+    pub fn new(packet_io: Arc<PacketIOController>) -> Self {
+        Self { packet_io }
+    }
+}
+
+#[async_trait]
+impl<T> StateModifier<T> for AmbientSoundModeCycleTwsStateModifier
+where
+    T: Has<TwsStatus>
+        + Has<AmbientSoundModeCycleTws>
+        + Has<ResetButtonConfigurationPending>
+        + Clone
+        + Send
+        + Sync,
+{
+    async fn move_to_state(
+        &self,
+        state_sender: &watch::Sender<T>,
+        target_state: &T,
+    ) -> device::Result<()> {
+        // If we are resetting buttons to default, don't immediately put them back as they were afterwards
+        let is_reset_pending: ResetButtonConfigurationPending = *target_state.get();
+        if is_reset_pending.0 {
+            return Ok(());
+        }
+
+        let target_cycle = target_state.get();
+        {
+            let state = state_sender.borrow();
+            let cycle: &AmbientSoundModeCycleTws = state.get();
+            if cycle == target_cycle {
+                return Ok(());
+            }
+        }
+
+        self.packet_io
+            .send_with_response(&packet::outbound::set_ambient_sound_mode_cycle_tws(
+                *target_cycle,
+            ))
+            .await?;
+        state_sender.send_modify(|state| *state.get_mut() = *target_cycle);
+        Ok(())
+    }
+}

--- a/lib/src/devices/soundcore/common/packet/outbound/set_ambient_sound_mode_cycle.rs
+++ b/lib/src/devices/soundcore/common/packet/outbound/set_ambient_sound_mode_cycle.rs
@@ -1,6 +1,6 @@
 use crate::devices::soundcore::common::{
     packet::{self, outbound::ToPacket},
-    structures::AmbientSoundModeCycle,
+    structures::{AmbientSoundModeCycle, AmbientSoundModeCycleTws},
 };
 
 #[derive(Clone, Copy, Debug, Default, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -18,4 +18,8 @@ impl ToPacket for SetAmbientSoundModeCycle {
     fn body(&self) -> Vec<u8> {
         vec![self.cycle.into()]
     }
+}
+
+pub fn set_ambient_sound_mode_cycle_tws(tws_cycle: AmbientSoundModeCycleTws) -> packet::Outbound {
+    packet::Outbound::new(packet::Command([0x06, 0x82]), vec![u8::from(tws_cycle)])
 }

--- a/lib/src/devices/soundcore/common/structures/ambient_sound_mode_cycle.rs
+++ b/lib/src/devices/soundcore/common/structures/ambient_sound_mode_cycle.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use nom::{
     IResult, Parser,
     combinator::map,
@@ -8,6 +10,39 @@ use nom::{
 const NOISE_CANCELING_MODE: u8 = 1 << 0;
 const TRANSPARENCY_MODE: u8 = 1 << 1;
 const NORMAL_MODE: u8 = 1 << 2;
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct AmbientSoundModeCycleTws {
+    pub tws_enabled: AmbientSoundModeCycle,
+    pub tws_disabled: AmbientSoundModeCycle,
+}
+
+impl AmbientSoundModeCycleTws {
+    pub fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context("ambient sound mode cycle tws", map(le_u8, Self::from)).parse_complete(input)
+    }
+
+    pub fn bytes(&self) -> impl Iterator<Item = u8> {
+        iter::once((*self).into())
+    }
+}
+
+impl From<u8> for AmbientSoundModeCycleTws {
+    fn from(value: u8) -> Self {
+        Self {
+            tws_disabled: AmbientSoundModeCycle::from(value >> 4),
+            tws_enabled: AmbientSoundModeCycle::from(value & 0xF),
+        }
+    }
+}
+
+impl From<AmbientSoundModeCycleTws> for u8 {
+    fn from(value: AmbientSoundModeCycleTws) -> Self {
+        (u8::from(value.tws_disabled) << 4) | u8::from(value.tws_enabled)
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct AmbientSoundModeCycle {

--- a/tools/soundcore-device-faker/devices/a3968.toml
+++ b/tools/soundcore-device-faker/devices/a3968.toml
@@ -6,23 +6,23 @@ rfcomm_uuid = "0CF12D31-FAC3-4553-BD80-D6832E7B3968"
 command = [1, 1]
 # State update
 response = [
-    0,
-    1,
-    5,
-    5,
-    0,
-    0,
-    48,
+    0,    # host device
+    1,    # tws connected
+    5,    # left battery
+    5,    # right battery
+    0,    # left battery charging
+    0,    # right battery charging
+    48,   # left FW start
     49,
     46,
     54,
-    53,
-    48,
+    53,   # left FW end
+    48,   # right FW start
     49,
     46,
     54,
-    53,
-    51,
+    53,   # right FW end
+    51,   # SN start
     57,
     54,
     56,
@@ -37,15 +37,16 @@ response = [
     98,
     101,
     57,
-    97,
+    97,   # SN end
     0,
     0,
     0,
     0,
     0,
-    2,
-    254,
-    254,
+    2,    # case battery level (0-5)
+    254,  # EQ preset
+    254,  # EQ preset
+    120,  # left EQ start
     120,
     120,
     120,
@@ -54,8 +55,8 @@ response = [
     120,
     120,
     120,
-    120,
-    120,
+    120,  # left EQ end
+    255,  # right EQ start
     255,
     255,
     255,
@@ -64,11 +65,10 @@ response = [
     255,
     255,
     255,
-    255,
-    48,
-    1,
-    1,
-    135,
+    48,   # right EQ end?
+    1,    # unknown
+    1,    # hear id enabled?
+    135,  # left hear id eq start
     114,
     140,
     142,
@@ -77,8 +77,8 @@ response = [
     166,
     134,
     60,
-    60,
-    135,
+    60,   # left hear id eq end
+    135,  # right hear id eq start
     114,
     140,
     142,
@@ -87,23 +87,13 @@ response = [
     166,
     134,
     60,
-    60,
-    255,
-    255,
-    255,
-    255,
-    1,
-    151,
-    151,
-    140,
-    143,
-    151,
-    145,
-    165,
-    134,
-    60,
-    0,
-    151,
+    60,   # right hear id eq end
+    255,  # hear id time?
+    255,  # hear id time?
+    255,  # hear id time?
+    255,  # hear id time?
+    0,    # hear id type (0=initial curve, 1=custom hearid, 2=favorite music genre)
+    151,  # left hear id custom eq start
     151,
     140,
     143,
@@ -112,30 +102,40 @@ response = [
     165,
     134,
     60,
-    0,
-    0,
-    0,
+    0,    # left hear id custom eq end
+    151,  # right hear id custom eq start
+    151,
+    140,
+    143,
+    151,
+    145,
+    165,
+    134,
+    60,
+    0,    # right hear id custom eq end
+    0,    # hear id favorite music genre
+    0,    # hear id favorite music genre
     8,
-    97,
-    102,
-    48,
-    51,
-    68,
-    68,
-    55,
+    0x61, # left single press
+    0x66, # right single press
+    0x30, # left double press
+    0x33, # right double press
+    0x44, # left long press
+    0x44, # right long press
+    0x37,
+    0,    # ambient sound mode
+    0x22, # manual (1-3) / adaptive (0-2) ANC
+    1,    # transparency mode
+    0,    # noise canceling mode
+    0,    # wind noise (unknown if it has a wind noise detected flag)
+    255,  # unknown
+    54,   # multi scene anc
+    1,    # 3d surround sound
     0,
-    50,
-    1,
-    0,
-    0,
-    255,
-    54,
-    1,
-    0,
-    1,
-    0,
-    1,
-    2,
+    1,    # dual connections
+    0,    # press alert
+    1,    # auto power off
+    2,    # auto power off duration
     1,
     255,
     255,

--- a/tools/soundcore-device-faker/devices/a3968.toml
+++ b/tools/soundcore-device-faker/devices/a3968.toml
@@ -129,7 +129,7 @@ response = [
     0,    # noise canceling mode
     0,    # wind noise (unknown if it has a wind noise detected flag)
     255,  # unknown
-    54,   # multi scene anc
+    54,   # unknown
     1,    # 3d surround sound
     0,
     1,    # dual connections

--- a/tools/soundcore-device-faker/devices/a3968.toml
+++ b/tools/soundcore-device-faker/devices/a3968.toml
@@ -122,7 +122,7 @@ response = [
     0x33, # right double press
     0x44, # left long press
     0x44, # right long press
-    0x37,
+    0x37, # ambient sound mode cycle (left 4 bits for tws off, right 4 bits for tws on)
     0,    # ambient sound mode
     0x22, # manual (1-3) / adaptive (0-2) ANC
     1,    # transparency mode


### PR DESCRIPTION
Adds the Soundcore Sport X20 (A3968). Closes #170.

I have one of these, so I grabbed the state update packet and worked out the byte layout. It's the same RFCOMM protocol as the other devices (command `[1, 1]`, 143-byte body).

**What works (read and set):**
- sound modes: normal / transparency / noise cancelling, plus adaptive and manual noise cancelling and the manual level
- battery for both buds, charging, serial number, firmware

**On the implementation:** the sound-mode block looked identical to the A3959 (P30i), so I reused its `SoundModes` struct and the `a3959_sound_modes` builder instead of duplicating it (which meant making a3959's `structures` and `modules` visible to the new module). If you'd rather I copy it into the a3968 module or pull the shared part into `common`, just say so and I'll change it.

One device quirk worth flagging: it reports an adaptive-sensitivity value of `255`, and echoing that back makes it refuse to switch into noise cancelling — so I normalize it to `0` on parse.

**EQ is intentionally left out for now.** None of the standard equalizer set commands do anything on this device (I tried plain `[0x02, 0x81]`, DRC `[0x02, 0x83]`, and the TWS variant, with both 8- and 10-band bodies), so I think its EQ is bundled with hear id and needs more reverse engineering. I did find where it lives in the state packet (preset id + 8 bands at offset 38, `120` = 0 dB), so I'm happy to do it as a follow-up. I can also add a `soundcore-device-faker` config if you'd like one.

Tested against my own unit and the state update packet posted in #170 (added as a parser test).
