### PR TITLE
[Manual] fix incorrect usage of .PP

### DIFF
--- a/cli/resources/manual/openscq30.1
+++ b/cli/resources/manual/openscq30.1
@@ -152,7 +152,7 @@ Create a new equalizer profile named "new profile"
 .B
 --set "customEqualizerProfile=+new profile"
 .fi
-.PP
+
 
 .IP
 Delete an equalizer profile named "new profile"
@@ -160,7 +160,7 @@ Delete an equalizer profile named "new profile"
 .B
 --set "customEqualizerProfile=-new profile"
 .fi
-.PP
+
 
 .IP
 Activate an equalizer profile named "+new profile"
@@ -168,14 +168,13 @@ Activate an equalizer profile named "+new profile"
 .B
 --set "customEqualizerProfile=\+new profile"
 .fi
-.PP
 
+.PP
 Equalizers: All bands must be specified, and numbers should be separated with ','. Examples:
 .IP
 \fB--set volumeAdjustments -40,-30,-20,-10,0,1,2,3\fR when fractional digits is 1
 (see \fBopenscq30 device list-settings --help\fR for info on fractional digits) will
 assign [-4, -3, -2, -1, 0, 0.1, 0.2, 0.3].
-.PP
 .RE
 
 .SS


### PR DESCRIPTION
.PP was used incorrectly. the formating hasn't been changed with this fix