### PR TITLE
feat(android): automatically enable transparency mode during calls

### DIFF
--- a/android/app/src/main/java/com/oppzippy/openscq30/features/callautomation/AudioCallStateMonitor.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/features/callautomation/AudioCallStateMonitor.kt
@@ -1,0 +1,44 @@
+package com.oppzippy.openscq30.features.callautomation
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flow
+
+class AudioCallStateMonitor(context: Context) {
+    private val audioManager = context.getSystemService(AudioManager::class.java)
+    private val callbackExecutor = ContextCompat.getMainExecutor(context)
+
+    fun states(): Flow<Boolean> = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        listenerStates()
+    } else {
+        pollingStates()
+    }.distinctUntilChanged()
+
+    @RequiresApi(Build.VERSION_CODES.S)
+    private fun listenerStates(): Flow<Boolean> = callbackFlow {
+        val listener = AudioManager.OnModeChangedListener { mode ->
+            trySend(isCallAudioMode(mode))
+        }
+        audioManager.addOnModeChangedListener(callbackExecutor, listener)
+        trySend(isCallAudioMode(audioManager.mode))
+        awaitClose { audioManager.removeOnModeChangedListener(listener) }
+    }
+
+    private fun pollingStates(): Flow<Boolean> = flow {
+        while (true) {
+            emit(isCallAudioMode(audioManager.mode))
+            delay(500)
+        }
+    }
+}
+
+internal fun isCallAudioMode(mode: Int): Boolean =
+    mode == AudioManager.MODE_IN_CALL || mode == AudioManager.MODE_IN_COMMUNICATION

--- a/android/app/src/main/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyController.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyController.kt
@@ -1,0 +1,66 @@
+package com.oppzippy.openscq30.features.callautomation
+
+import com.oppzippy.openscq30.lib.bindings.OpenScq30Device
+import com.oppzippy.openscq30.lib.bindings.SettingIdValuePair
+import com.oppzippy.openscq30.lib.wrapper.Setting
+import com.oppzippy.openscq30.lib.wrapper.toValue
+
+internal const val AMBIENT_SOUND_MODE_SETTING_ID = "ambientSoundMode"
+internal const val TRANSPARENCY_MODE = "Transparency"
+
+internal interface AmbientModeGateway {
+    fun currentMode(): String?
+
+    suspend fun setMode(mode: String)
+}
+
+internal class OpenScq30AmbientModeGateway(private val device: OpenScq30Device) : AmbientModeGateway {
+    override fun currentMode(): String? =
+        (device.setting(AMBIENT_SOUND_MODE_SETTING_ID) as? Setting.SelectSetting)?.value
+
+    override suspend fun setMode(mode: String) {
+        device.setSettingValues(
+            listOf(SettingIdValuePair(AMBIENT_SOUND_MODE_SETTING_ID, mode.toValue())),
+        )
+    }
+}
+
+internal class CallTransparencyController(private val ambientModeGateway: AmbientModeGateway) {
+    private var callActive = false
+    private var previousMode: String? = null
+    private var changedByAutomation = false
+
+    suspend fun onCallStateChanged(active: Boolean) {
+        if (active == callActive) {
+            return
+        }
+
+        if (active) {
+            activateTransparency()
+        } else {
+            restorePreviousMode()
+        }
+    }
+
+    private suspend fun activateTransparency() {
+        val currentMode = ambientModeGateway.currentMode() ?: return
+        if (currentMode != TRANSPARENCY_MODE) {
+            ambientModeGateway.setMode(TRANSPARENCY_MODE)
+            previousMode = currentMode
+            changedByAutomation = true
+        }
+        callActive = true
+    }
+
+    private suspend fun restorePreviousMode() {
+        val modeToRestore = previousMode?.takeIf {
+            changedByAutomation && ambientModeGateway.currentMode() == TRANSPARENCY_MODE
+        }
+        callActive = false
+        previousMode = null
+        changedByAutomation = false
+        if (modeToRestore != null) {
+            ambientModeGateway.setMode(modeToRestore)
+        }
+    }
+}

--- a/android/app/src/main/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyController.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyController.kt
@@ -8,15 +8,25 @@ import com.oppzippy.openscq30.lib.wrapper.toValue
 internal const val AMBIENT_SOUND_MODE_SETTING_ID = "ambientSoundMode"
 internal const val TRANSPARENCY_MODE = "Transparency"
 
+internal data class AmbientModeState(val currentMode: String, val transparencyMode: String)
+
 internal interface AmbientModeGateway {
-    fun currentMode(): String?
+    fun state(): AmbientModeState?
 
     suspend fun setMode(mode: String)
 }
 
 internal class OpenScq30AmbientModeGateway(private val device: OpenScq30Device) : AmbientModeGateway {
-    override fun currentMode(): String? =
-        (device.setting(AMBIENT_SOUND_MODE_SETTING_ID) as? Setting.SelectSetting)?.value
+    override fun state(): AmbientModeState? {
+        val setting = device.setting(AMBIENT_SOUND_MODE_SETTING_ID) as? Setting.SelectSetting ?: return null
+        val transparencyMode = setting.setting.options.firstOrNull {
+            it.equals(TRANSPARENCY_MODE, ignoreCase = true)
+        } ?: return null
+        return AmbientModeState(
+            currentMode = setting.value,
+            transparencyMode = transparencyMode,
+        )
+    }
 
     override suspend fun setMode(mode: String) {
         device.setSettingValues(
@@ -43,18 +53,19 @@ internal class CallTransparencyController(private val ambientModeGateway: Ambien
     }
 
     private suspend fun activateTransparency() {
-        val currentMode = ambientModeGateway.currentMode() ?: return
-        if (currentMode != TRANSPARENCY_MODE) {
-            ambientModeGateway.setMode(TRANSPARENCY_MODE)
-            previousMode = currentMode
+        val state = ambientModeGateway.state() ?: return
+        if (state.currentMode != state.transparencyMode) {
+            ambientModeGateway.setMode(state.transparencyMode)
+            previousMode = state.currentMode
             changedByAutomation = true
         }
         callActive = true
     }
 
     private suspend fun restorePreviousMode() {
+        val state = ambientModeGateway.state()
         val modeToRestore = previousMode?.takeIf {
-            changedByAutomation && ambientModeGateway.currentMode() == TRANSPARENCY_MODE
+            changedByAutomation && state != null && state.currentMode == state.transparencyMode
         }
         callActive = false
         previousMode = null

--- a/android/app/src/main/java/com/oppzippy/openscq30/features/preferences/Preferences.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/features/preferences/Preferences.kt
@@ -23,6 +23,7 @@ class Preferences @Inject constructor(@ApplicationContext context: Context) {
         const val TAG = "Preferences"
 
         private const val PREFERENCE_AUTO_CONNECT = "autoConnect"
+        private const val PREFERENCE_AUTO_TRANSPARENCY_DURING_CALLS = "autoTransparencyDuringCalls"
         private const val PREFERENCE_THEME = "theme"
         private const val PREFERENCE_DYNAMIC_COLOR = "dynamicColor"
     }
@@ -32,6 +33,10 @@ class Preferences @Inject constructor(@ApplicationContext context: Context) {
     private val autoConnectPreference = Preference(
         get = { preferences.getBoolean(PREFERENCE_AUTO_CONNECT, false) },
         set = { preferences.edit { putBoolean(PREFERENCE_AUTO_CONNECT, it) } },
+    )
+    private val autoTransparencyDuringCallsPreference = Preference(
+        get = { preferences.getBoolean(PREFERENCE_AUTO_TRANSPARENCY_DURING_CALLS, false) },
+        set = { preferences.edit { putBoolean(PREFERENCE_AUTO_TRANSPARENCY_DURING_CALLS, it) } },
     )
     private val themePreference = Preference(
         get = {
@@ -61,6 +66,7 @@ class Preferences @Inject constructor(@ApplicationContext context: Context) {
 
     private val preferenceKeysToPreferences = mapOf(
         PREFERENCE_AUTO_CONNECT to autoConnectPreference,
+        PREFERENCE_AUTO_TRANSPARENCY_DURING_CALLS to autoTransparencyDuringCallsPreference,
         PREFERENCE_THEME to themePreference,
         PREFERENCE_DYNAMIC_COLOR to dynamicColorPreference,
     )
@@ -104,6 +110,11 @@ class Preferences @Inject constructor(@ApplicationContext context: Context) {
     var autoConnect: Boolean
         get() = autoConnectPreference.flow.value
         set(value) = autoConnectPreference.set(value)
+
+    val autoTransparencyDuringCallsFlow = autoTransparencyDuringCallsPreference.flow
+    var autoTransparencyDuringCalls: Boolean
+        get() = autoTransparencyDuringCallsPreference.flow.value
+        set(value) = autoTransparencyDuringCallsPreference.set(value)
 
     val themeFlow = themePreference.flow
     var theme: ThemeType?

--- a/android/app/src/main/java/com/oppzippy/openscq30/features/soundcoredevice/service/DeviceService.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/features/soundcoredevice/service/DeviceService.kt
@@ -18,6 +18,10 @@ import androidx.glance.appwidget.GlanceAppWidgetManager
 import androidx.lifecycle.LifecycleService
 import androidx.lifecycle.lifecycleScope
 import com.oppzippy.openscq30.R
+import com.oppzippy.openscq30.features.callautomation.AudioCallStateMonitor
+import com.oppzippy.openscq30.features.callautomation.CallTransparencyController
+import com.oppzippy.openscq30.features.callautomation.OpenScq30AmbientModeGateway
+import com.oppzippy.openscq30.features.preferences.Preferences
 import com.oppzippy.openscq30.features.soundcoredevice.connectionBackends
 import com.oppzippy.openscq30.features.statusnotification.storage.FeaturedSettingSlotDao
 import com.oppzippy.openscq30.features.statusnotification.storage.QuickPresetSlotDao
@@ -40,6 +44,7 @@ import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -88,6 +93,9 @@ class DeviceService : LifecycleService() {
 
     @Inject
     lateinit var featuredSettingSlotDao: FeaturedSettingSlotDao
+
+    @Inject
+    lateinit var preferences: Preferences
 
     val connectionStatusFlow: MutableStateFlow<ConnectionStatus> =
         MutableStateFlow(ConnectionStatus.AwaitingConnection)
@@ -194,6 +202,32 @@ class DeviceService : LifecycleService() {
 
         lifecycleScope.launch { quickPresetNames.collectLatest { sendNotification() } }
         lifecycleScope.launch { featuredSettingIds.collectLatest { sendNotification() } }
+
+        lifecycleScope.launch {
+            connectionStatusFlow.collectLatest { connectionStatus ->
+                if (connectionStatus is ConnectionStatus.Connected) {
+                    val controller = CallTransparencyController(
+                        OpenScq30AmbientModeGateway(connectionStatus.deviceManager.device),
+                    )
+                    preferences.autoTransparencyDuringCallsFlow
+                        .flatMapLatest { enabled ->
+                            if (enabled) {
+                                AudioCallStateMonitor(applicationContext).states()
+                            } else {
+                                flowOf(false)
+                            }
+                        }.collect { callActive ->
+                            try {
+                                controller.onCallStateChanged(callActive)
+                            } catch (ex: OpenScq30Exception) {
+                                Log.e(TAG, "failed to update ambient sound mode for call state", ex)
+                            } catch (ex: IllegalStateException) {
+                                Log.e(TAG, "failed to update ambient sound mode for call state", ex)
+                            }
+                        }
+                }
+            }
+        }
 
         ContextCompat.registerReceiver(
             this,

--- a/android/app/src/main/java/com/oppzippy/openscq30/ui/settings/Settings.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/ui/settings/Settings.kt
@@ -3,17 +3,28 @@ package com.oppzippy.openscq30.ui.settings
 import android.os.Build
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -68,10 +79,9 @@ private fun Settings(
             onCheckedChange = { onAutoConnectChange(it) },
         )
 
-        LabeledSwitch(
-            label = stringResource(R.string.auto_transparency_during_calls),
-            isChecked = autoTransparencyDuringCalls,
-            onCheckedChange = onAutoTransparencyDuringCallsChange,
+        CallTransparencyAutomationCard(
+            enabled = autoTransparencyDuringCalls,
+            onEnabledChange = onAutoTransparencyDuringCallsChange,
         )
 
         val themes = listOf(
@@ -105,6 +115,55 @@ private fun Settings(
             onClick = { onCopyLogsUnfiltered() },
             content = { Text(stringResource(R.string.copy_logs_to_clipboard_unfiltered)) },
         )
+    }
+}
+
+@Composable
+private fun CallTransparencyAutomationCard(enabled: Boolean, onEnabledChange: (Boolean) -> Unit) {
+    val state = stringResource(
+        if (enabled) R.string.call_transparency_automation_enabled else R.string.call_transparency_automation_disabled,
+    )
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                role = Role.Switch
+                toggleableState = ToggleableState(enabled)
+                stateDescription = state
+            },
+        onClick = { onEnabledChange(!enabled) },
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.call_transparency_automation),
+                        style = MaterialTheme.typography.titleMedium,
+                    )
+                    Text(
+                        text = state,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                Switch(
+                    checked = enabled,
+                    onCheckedChange = null,
+                )
+            }
+            Text(
+                text = stringResource(R.string.call_transparency_automation_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
     }
 }
 

--- a/android/app/src/main/java/com/oppzippy/openscq30/ui/settings/Settings.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/ui/settings/Settings.kt
@@ -26,11 +26,14 @@ import com.oppzippy.openscq30.ui.utils.Select
 @Composable
 fun Settings(viewModel: SettingsViewModel = hiltViewModel()) {
     val autoConnect by viewModel.autoConnect.collectAsState()
+    val autoTransparencyDuringCalls by viewModel.autoTransparencyDuringCalls.collectAsState()
     val theme by viewModel.theme.collectAsState()
     val dynamicColorEnabled by viewModel.dynamicColorEnabled.collectAsState()
     Settings(
         autoConnect = autoConnect,
         onAutoConnectChange = { viewModel.setAutoConnect(it) },
+        autoTransparencyDuringCalls = autoTransparencyDuringCalls,
+        onAutoTransparencyDuringCallsChange = { viewModel.setAutoTransparencyDuringCalls(it) },
         theme = theme,
         onThemeChange = { viewModel.setTheme(it) },
         dynamicColorEnabled = dynamicColorEnabled,
@@ -44,6 +47,8 @@ fun Settings(viewModel: SettingsViewModel = hiltViewModel()) {
 private fun Settings(
     autoConnect: Boolean,
     onAutoConnectChange: (Boolean) -> Unit,
+    autoTransparencyDuringCalls: Boolean,
+    onAutoTransparencyDuringCallsChange: (Boolean) -> Unit,
     theme: ThemeType?,
     onThemeChange: (ThemeType?) -> Unit,
     dynamicColorEnabled: Boolean,
@@ -61,6 +66,12 @@ private fun Settings(
             label = stringResource(R.string.auto_connect),
             isChecked = autoConnect,
             onCheckedChange = { onAutoConnectChange(it) },
+        )
+
+        LabeledSwitch(
+            label = stringResource(R.string.auto_transparency_during_calls),
+            isChecked = autoTransparencyDuringCalls,
+            onCheckedChange = onAutoTransparencyDuringCallsChange,
         )
 
         val themes = listOf(
@@ -104,6 +115,8 @@ private fun PreviewSettings() {
         Settings(
             autoConnect = false,
             onAutoConnectChange = {},
+            autoTransparencyDuringCalls = false,
+            onAutoTransparencyDuringCallsChange = {},
             theme = null,
             onThemeChange = {},
             dynamicColorEnabled = true,

--- a/android/app/src/main/java/com/oppzippy/openscq30/ui/settings/SettingsViewModel.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/ui/settings/SettingsViewModel.kt
@@ -27,6 +27,7 @@ class SettingsViewModel @Inject constructor(
     }
 
     val autoConnect = preferences.autoConnectFlow
+    val autoTransparencyDuringCalls = preferences.autoTransparencyDuringCallsFlow
     val theme = preferences.themeFlow
     val dynamicColorEnabled = preferences.dynamicColorFlow
 
@@ -38,6 +39,10 @@ class SettingsViewModel @Inject constructor(
         } else {
             context.stopService(intent)
         }
+    }
+
+    fun setAutoTransparencyDuringCalls(value: Boolean) {
+        preferences.autoTransparencyDuringCalls = value
     }
 
     fun setTheme(theme: ThemeType?) {

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="awaiting_connection">Awaiting Connection</string>
     <string name="quick_presets">Quick Presets</string>
     <string name="auto_connect">Auto Connect</string>
+    <string name="auto_transparency_during_calls" translatable="false">Automatically use transparency mode during calls</string>
     <string name="settings">Settings</string>
     <string name="unpair_device">Unpair Device</string>
     <string name="unpairing_from_device_name">Unpairing From %s</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -45,7 +45,10 @@
     <string name="awaiting_connection">Awaiting Connection</string>
     <string name="quick_presets">Quick Presets</string>
     <string name="auto_connect">Auto Connect</string>
-    <string name="auto_transparency_during_calls" translatable="false">Automatically use transparency mode during calls</string>
+    <string name="call_transparency_automation">Call transparency automation</string>
+    <string name="call_transparency_automation_description">For supported Soundcore headphones, use transparency mode only while a phone or internet call is active, then restore the previous mode.</string>
+    <string name="call_transparency_automation_enabled">Enabled</string>
+    <string name="call_transparency_automation_disabled">Disabled</string>
     <string name="settings">Settings</string>
     <string name="unpair_device">Unpair Device</string>
     <string name="unpairing_from_device_name">Unpairing From %s</string>

--- a/android/app/src/test/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyControllerTest.kt
+++ b/android/app/src/test/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyControllerTest.kt
@@ -1,0 +1,79 @@
+package com.oppzippy.openscq30.features.callautomation
+
+import android.media.AudioManager
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CallTransparencyControllerTest {
+    @Test
+    fun `switches to transparency during a call and restores the previous mode`() = runTest {
+        val gateway = FakeAmbientModeGateway("NoiseCanceling")
+        val controller = CallTransparencyController(gateway)
+
+        controller.onCallStateChanged(true)
+        controller.onCallStateChanged(false)
+
+        assertEquals(listOf("Transparency", "NoiseCanceling"), gateway.setModes)
+        assertEquals("NoiseCanceling", gateway.currentMode())
+    }
+
+    @Test
+    fun `does not change or restore when transparency was already active`() = runTest {
+        val gateway = FakeAmbientModeGateway("Transparency")
+        val controller = CallTransparencyController(gateway)
+
+        controller.onCallStateChanged(true)
+        controller.onCallStateChanged(false)
+
+        assertTrue(gateway.setModes.isEmpty())
+    }
+
+    @Test
+    fun `does not overwrite a mode selected by the user during the call`() = runTest {
+        val gateway = FakeAmbientModeGateway("NoiseCanceling")
+        val controller = CallTransparencyController(gateway)
+
+        controller.onCallStateChanged(true)
+        gateway.mode = "Normal"
+        controller.onCallStateChanged(false)
+
+        assertEquals(listOf("Transparency"), gateway.setModes)
+        assertEquals("Normal", gateway.currentMode())
+    }
+
+    @Test
+    fun `ignores repeated call state notifications`() = runTest {
+        val gateway = FakeAmbientModeGateway("Normal")
+        val controller = CallTransparencyController(gateway)
+
+        controller.onCallStateChanged(true)
+        controller.onCallStateChanged(true)
+        controller.onCallStateChanged(false)
+        controller.onCallStateChanged(false)
+
+        assertEquals(listOf("Transparency", "Normal"), gateway.setModes)
+    }
+
+    @Test
+    fun `recognizes phone and internet call audio modes`() {
+        assertTrue(isCallAudioMode(AudioManager.MODE_IN_CALL))
+        assertTrue(isCallAudioMode(AudioManager.MODE_IN_COMMUNICATION))
+        assertFalse(isCallAudioMode(AudioManager.MODE_NORMAL))
+        assertFalse(isCallAudioMode(AudioManager.MODE_RINGTONE))
+    }
+
+    private class FakeAmbientModeGateway(initialMode: String?) : AmbientModeGateway {
+        var mode = initialMode
+        val setModes = mutableListOf<String>()
+
+        override fun currentMode(): String? = mode
+
+        override suspend fun setMode(mode: String) {
+            this.mode = mode
+            setModes += mode
+        }
+    }
+}

--- a/android/app/src/test/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyControllerTest.kt
+++ b/android/app/src/test/java/com/oppzippy/openscq30/features/callautomation/CallTransparencyControllerTest.kt
@@ -17,7 +17,7 @@ class CallTransparencyControllerTest {
         controller.onCallStateChanged(false)
 
         assertEquals(listOf("Transparency", "NoiseCanceling"), gateway.setModes)
-        assertEquals("NoiseCanceling", gateway.currentMode())
+        assertEquals("NoiseCanceling", gateway.mode)
     }
 
     @Test
@@ -41,7 +41,7 @@ class CallTransparencyControllerTest {
         controller.onCallStateChanged(false)
 
         assertEquals(listOf("Transparency"), gateway.setModes)
-        assertEquals("Normal", gateway.currentMode())
+        assertEquals("Normal", gateway.mode)
     }
 
     @Test
@@ -65,11 +65,30 @@ class CallTransparencyControllerTest {
         assertFalse(isCallAudioMode(AudioManager.MODE_RINGTONE))
     }
 
-    private class FakeAmbientModeGateway(initialMode: String?) : AmbientModeGateway {
+    @Test
+    fun `does nothing when the connected device has no transparency mode`() = runTest {
+        val gateway = FakeAmbientModeGateway("NoiseCanceling", transparencyMode = null)
+        val controller = CallTransparencyController(gateway)
+
+        controller.onCallStateChanged(true)
+        controller.onCallStateChanged(false)
+
+        assertTrue(gateway.setModes.isEmpty())
+        assertEquals("NoiseCanceling", gateway.mode)
+    }
+
+    private class FakeAmbientModeGateway(
+        initialMode: String?,
+        private val transparencyMode: String? = "Transparency",
+    ) : AmbientModeGateway {
         var mode = initialMode
         val setModes = mutableListOf<String>()
 
-        override fun currentMode(): String? = mode
+        override fun state(): AmbientModeState? {
+            val currentMode = mode ?: return null
+            val availableTransparencyMode = transparencyMode ?: return null
+            return AmbientModeState(currentMode, availableTransparencyMode)
+        }
 
         override suspend fun setMode(mode: String) {
             this.mode = mode


### PR DESCRIPTION
## Motivation

When making a call with noise cancellation enabled, hearing your own voice differently can cause you to speak louder than intended or create an uncomfortable occluded feeling. Similar to earbuds that automatically enable transparency mode during calls, this PR makes the same behavior optionally available for devices supported by OpenSCQ30.

Related issue: #324

## Changes

- Added a `Call transparency automation` switch to the Android settings screen.
- The feature is disabled by default and only runs when explicitly enabled by the user.
- Detects Android call audio modes, saves the current ambient sound mode when a call starts, and switches the device to `Transparency`.
- When the call ends, the previous mode is restored only if the earbuds are still in the `Transparency` mode set by the automation. A mode manually selected by the user during the call is not overwritten.
- Disabling the feature during a call stops monitoring and restores the previous mode when necessary.
- The feature only operates when the connected device exposes both the `ambientSoundMode` setting and a `Transparency` option. No command is sent to unsupported devices.
- Android 12 and later use an audio mode change callback, while earlier versions poll the current state periodically.

## Validation

- Verified the basic switching and restoration flow for regular phone calls using a P31i (D1202).
- Internet call detection is not yet consistent across applications and the audio modes they expose, so additional real-device testing is still required.
- I only own a P31i and could not test other earbuds. The implementation does not use model-specific packets; it checks the settings exposed by the connected device so that it can work with other devices that provide the same settings.
- Added unit tests covering automatic switching and restoration, calls that start while transparency mode is already active, manual mode changes during calls, repeated state notifications, and unsupported devices.
- `just format-check`
- `./gradlew testX86_64DebugUnitTest`
- `./gradlew assembleArm64-v8aDebug`
- `git diff --check`

This PR was created with the assistance of AI tools.
