### PR TITLE
feat(lib): support d1301 auto-switch once asleep

### DIFF
--- a/lib/i18n/en/openscq30-lib.ftl
+++ b/lib/i18n/en/openscq30-lib.ftl
@@ -292,6 +292,10 @@ noise-canceling-prompt = Noise Canceling Prompt
 
 auto-stop-timer = Auto Stop Timer
 auto-stop-timer-duration = Auto Stop Timer Duration
+auto-switch-once-asleep = Auto-Switch Once Asleep
+keep-audio = Keep Audio
+pause-audio = Pause Audio
+play-local-audio = Play Local Audio, ANC Off
 
 alarms = Alarms
 

--- a/lib/src/api/settings.rs
+++ b/lib/src/api/settings.rs
@@ -180,6 +180,7 @@ pub enum SettingId {
     NoiseCancelingPrompt,
     AutoStopTimer,
     AutoStopTimerDuration,
+    AutoSwitchOnceAsleep,
     Alarms,
     ListeningMode,
     DefaultListeningMode,

--- a/lib/src/devices/soundcore/d1301.rs
+++ b/lib/src/devices/soundcore/d1301.rs
@@ -60,6 +60,7 @@ soundcore_device!(
 
         // misc
         builder.d1301_auto_stop_timer();
+        builder.d1301_auto_switch_once_asleep();
         builder.d1301_listening_mode();
         builder.d1301_noise_canceling();
 

--- a/lib/src/devices/soundcore/d1301/modules.rs
+++ b/lib/src/devices/soundcore/d1301/modules.rs
@@ -2,6 +2,7 @@ use crate::devices::soundcore::{common::device::SoundcoreDeviceBuilder, d1301::s
 
 mod alarms;
 mod auto_stop_timer;
+mod auto_switch_once_asleep;
 mod flags;
 mod listening_mode;
 
@@ -33,6 +34,12 @@ impl SoundcoreDeviceBuilder<D1301State> {
         let packet_io = self.packet_io_controller().clone();
         self.module_collection()
             .add_d1301_auto_stop_timer(packet_io);
+    }
+
+    pub fn d1301_auto_switch_once_asleep(&mut self) {
+        let packet_io = self.packet_io_controller().clone();
+        self.module_collection()
+            .add_d1301_auto_switch_once_asleep(packet_io);
     }
 
     pub fn d1301_listening_mode(&mut self) {

--- a/lib/src/devices/soundcore/d1301/modules/auto_stop_timer.rs
+++ b/lib/src/devices/soundcore/d1301/modules/auto_stop_timer.rs
@@ -1,3 +1,4 @@
+mod packet_handler;
 mod setting_handler;
 mod state_modifier;
 
@@ -37,5 +38,9 @@ where
             .push(Box::new(state_modifier::AutoStopTimerStateModifier::new(
                 packet_io,
             )));
+        self.packet_handlers.set_handler(
+            packet_handler::AutoStopTimerPacketHandler::COMMAND,
+            Box::new(packet_handler::AutoStopTimerPacketHandler),
+        );
     }
 }

--- a/lib/src/devices/soundcore/d1301/modules/auto_stop_timer/packet_handler.rs
+++ b/lib/src/devices/soundcore/d1301/modules/auto_stop_timer/packet_handler.rs
@@ -1,0 +1,45 @@
+use async_trait::async_trait;
+use openscq30_lib_has::Has;
+use tokio::sync::watch;
+
+use crate::{
+    api::device,
+    devices::soundcore::{
+        common::{
+            packet::{self, Command, inbound::TryToPacket},
+            packet_manager::PacketHandler,
+        },
+        d1301::{packets::inbound::AutoStopTimerPacket, structures::AutoStopTimer},
+    },
+};
+
+/// Handles the 21 3 the device sends when the auto stop timer changes. Without
+/// it the packet is logged as unhandled and the change is not seen until the
+/// next connect.
+#[derive(Default)]
+pub struct AutoStopTimerPacketHandler;
+
+impl AutoStopTimerPacketHandler {
+    pub const COMMAND: Command = AutoStopTimerPacket::COMMAND;
+}
+
+#[async_trait]
+impl<T> PacketHandler<T> for AutoStopTimerPacketHandler
+where
+    T: Has<AutoStopTimer> + Send + Sync,
+{
+    async fn handle_packet(
+        &self,
+        state: &watch::Sender<T>,
+        packet: &packet::Inbound,
+    ) -> device::Result<()> {
+        let packet: AutoStopTimerPacket = packet.try_to_packet()?;
+        state.send_if_modified(|state| {
+            let auto_stop_timer: &mut AutoStopTimer = state.get_mut();
+            let modified = *auto_stop_timer != packet.0;
+            *auto_stop_timer = packet.0;
+            modified
+        });
+        Ok(())
+    }
+}

--- a/lib/src/devices/soundcore/d1301/modules/auto_switch_once_asleep.rs
+++ b/lib/src/devices/soundcore/d1301/modules/auto_switch_once_asleep.rs
@@ -1,0 +1,43 @@
+mod setting_handler;
+mod state_modifier;
+
+use std::sync::Arc;
+
+use openscq30_lib_has::Has;
+use strum::{EnumIter, EnumString, IntoStaticStr};
+
+use crate::{
+    api::settings::{CategoryId, SettingId},
+    devices::soundcore::{
+        common::{modules::ModuleCollection, packet::PacketIOController},
+        d1301,
+    },
+    macros::enum_subset,
+};
+
+enum_subset! {
+    SettingId,
+    #[derive(EnumString, EnumIter, IntoStaticStr)]
+    enum AutoSwitchOnceAsleepSetting {
+        AutoSwitchOnceAsleep,
+    }
+}
+
+impl<T> ModuleCollection<T>
+where
+    T: Has<d1301::structures::AutoSwitchOnceAsleep>
+        + Has<d1301::structures::PostSleepAudio>
+        + Clone
+        + Send
+        + Sync,
+{
+    pub fn add_d1301_auto_switch_once_asleep(&mut self, packet_io: Arc<PacketIOController>) {
+        self.setting_manager.add_handler(
+            CategoryId::Miscellaneous,
+            setting_handler::AutoSwitchOnceAsleepSettingHandler,
+        );
+        self.state_modifiers.push(Box::new(
+            state_modifier::AutoSwitchOnceAsleepStateModifier::new(packet_io),
+        ));
+    }
+}

--- a/lib/src/devices/soundcore/d1301/modules/auto_switch_once_asleep/setting_handler.rs
+++ b/lib/src/devices/soundcore/d1301/modules/auto_switch_once_asleep/setting_handler.rs
@@ -1,0 +1,100 @@
+use async_trait::async_trait;
+use openscq30_lib_has::Has;
+use strum::IntoEnumIterator;
+
+use crate::{
+    api::settings::{Setting, SettingId, Value},
+    devices::soundcore::{
+        common::settings_manager::{SettingHandler, SettingHandlerResult},
+        d1301::structures::{AutoSwitchOnceAsleep, PostSleepAudio},
+    },
+};
+
+use super::AutoSwitchOnceAsleepSetting;
+
+/// The three choices the official app offers. They are the three reachable
+/// combinations of the enable flag and the post-sleep audio action; with the
+/// feature off the action is retained but ignored.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    strum::IntoStaticStr,
+    strum::EnumString,
+    strum::EnumIter,
+    strum::VariantArray,
+    openscq30_i18n_macros::Translate,
+)]
+// Named after the app's labels, which keeps the translation keys specific.
+#[allow(clippy::enum_variant_names)]
+pub enum AutoSwitchOnceAsleepValue {
+    #[default]
+    KeepAudio,
+    PauseAudio,
+    PlayLocalAudio,
+}
+
+impl AutoSwitchOnceAsleepValue {
+    fn from_state(enabled: bool, post_sleep_audio: PostSleepAudio) -> Self {
+        match (enabled, post_sleep_audio) {
+            (false, _) => Self::KeepAudio,
+            (true, PostSleepAudio::PAUSE) => Self::PauseAudio,
+            (true, _) => Self::PlayLocalAudio,
+        }
+    }
+
+    /// The action to write, or `None` to leave it as it is.
+    fn post_sleep_audio(self) -> Option<PostSleepAudio> {
+        match self {
+            Self::KeepAudio => None,
+            Self::PauseAudio => Some(PostSleepAudio::PAUSE),
+            Self::PlayLocalAudio => Some(PostSleepAudio::PLAY_LOCAL),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct AutoSwitchOnceAsleepSettingHandler;
+
+#[async_trait]
+impl<T> SettingHandler<T> for AutoSwitchOnceAsleepSettingHandler
+where
+    T: Has<AutoSwitchOnceAsleep> + Has<PostSleepAudio> + Send,
+{
+    fn settings(&self) -> Vec<SettingId> {
+        AutoSwitchOnceAsleepSetting::iter()
+            .map(Into::into)
+            .collect()
+    }
+
+    fn get(&self, state: &T, setting_id: &SettingId) -> Option<Setting> {
+        let _: AutoSwitchOnceAsleepSetting = (*setting_id).try_into().ok()?;
+        let enabled: &AutoSwitchOnceAsleep = state.get();
+        let post_sleep_audio: &PostSleepAudio = state.get();
+        Some(Setting::select_from_enum_all_variants(
+            AutoSwitchOnceAsleepValue::from_state(enabled.0, *post_sleep_audio),
+        ))
+    }
+
+    async fn set(
+        &self,
+        state: &mut T,
+        _setting_id: &SettingId,
+        value: Value,
+    ) -> SettingHandlerResult<()> {
+        let selected: AutoSwitchOnceAsleepValue = value.try_as_enum_variant()?;
+
+        // Keep Audio only clears the enable flag, so re-enabling restores the
+        // previous action.
+        if let Some(action) = selected.post_sleep_audio() {
+            let post_sleep_audio: &mut PostSleepAudio = state.get_mut();
+            *post_sleep_audio = action;
+        }
+        let enabled: &mut AutoSwitchOnceAsleep = state.get_mut();
+        enabled.0 = selected != AutoSwitchOnceAsleepValue::KeepAudio;
+        Ok(())
+    }
+}

--- a/lib/src/devices/soundcore/d1301/modules/auto_switch_once_asleep/state_modifier.rs
+++ b/lib/src/devices/soundcore/d1301/modules/auto_switch_once_asleep/state_modifier.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use openscq30_lib_has::Has;
+use std::sync::Arc;
+use tokio::sync::watch;
+
+use crate::{
+    api::device,
+    devices::soundcore::{
+        common::{packet::PacketIOController, state_modifier::StateModifier},
+        d1301::{
+            self,
+            structures::{AutoSwitchOnceAsleep, PostSleepAudio},
+        },
+    },
+};
+
+pub struct AutoSwitchOnceAsleepStateModifier {
+    packet_io: Arc<PacketIOController>,
+}
+
+impl AutoSwitchOnceAsleepStateModifier {
+    pub fn new(packet_io: Arc<PacketIOController>) -> Self {
+        Self { packet_io }
+    }
+}
+
+#[async_trait]
+impl<StateT> StateModifier<StateT> for AutoSwitchOnceAsleepStateModifier
+where
+    StateT: Has<AutoSwitchOnceAsleep> + Has<PostSleepAudio> + Send + Sync,
+{
+    async fn move_to_state(
+        &self,
+        state_sender: &watch::Sender<StateT>,
+        target_state: &StateT,
+    ) -> device::Result<()> {
+        let (enabled, post_sleep_audio) = {
+            let state = state_sender.borrow();
+            let enabled: &AutoSwitchOnceAsleep = state.get();
+            let post_sleep_audio: &PostSleepAudio = state.get();
+            (*enabled, *post_sleep_audio)
+        };
+        let target_enabled: AutoSwitchOnceAsleep = *target_state.get();
+        let target_post_sleep_audio: PostSleepAudio = *target_state.get();
+
+        // The official app enables the feature before setting the action.
+        if enabled != target_enabled {
+            self.packet_io
+                .send_with_response(&d1301::packets::outbound::set_auto_switch_once_asleep(
+                    target_enabled,
+                ))
+                .await?;
+            state_sender.send_modify(|state| {
+                *state.get_mut() = target_enabled;
+            });
+        }
+
+        if post_sleep_audio != target_post_sleep_audio {
+            self.packet_io
+                .send_with_response(&d1301::packets::outbound::set_post_sleep_audio(
+                    target_post_sleep_audio,
+                ))
+                .await?;
+            state_sender.send_modify(|state| {
+                *state.get_mut() = target_post_sleep_audio;
+            });
+        }
+
+        Ok(())
+    }
+}

--- a/lib/src/devices/soundcore/d1301/packets/inbound/state_update.rs
+++ b/lib/src/devices/soundcore/d1301/packets/inbound/state_update.rs
@@ -37,6 +37,8 @@ pub struct D1301StateUpdatePacket {
     pub incoming_calls_during_bluetooth_mode: d1301::structures::IncomingCallsDuringBluetoothMode,
     pub tap_controls_disabled: d1301::structures::TapControlsDisabled,
     pub noise_canceling_prompt: d1301::structures::NoiseCancelingPrompt,
+    pub post_sleep_audio: d1301::structures::PostSleepAudio,
+    pub auto_switch_once_asleep: d1301::structures::AutoSwitchOnceAsleep,
 }
 
 impl Default for D1301StateUpdatePacket {
@@ -57,6 +59,8 @@ impl Default for D1301StateUpdatePacket {
             incoming_calls_during_bluetooth_mode: Default::default(),
             tap_controls_disabled: Default::default(),
             noise_canceling_prompt: Default::default(),
+            post_sleep_audio: Default::default(),
+            auto_switch_once_asleep: Default::default(),
         }
     }
 }
@@ -79,7 +83,10 @@ impl FromPacketBody for D1301StateUpdatePacket {
                         take(6usize),
                         FirmwareVersion::take, // case firmware version
                         take(4usize),
-                        le_u8, // auto switch once asleep, but unknown how it works
+                        // Not auto switch once asleep, despite appearances:
+                        // reads 6 on every device seen so far and never changed
+                        // when that setting changed. Still unidentified.
+                        le_u8,
                         ButtonStatusCollection::take(
                             d1301::BUTTON_CONFIGURATION_SETTINGS.parse_settings(),
                         ),
@@ -96,9 +103,12 @@ impl FromPacketBody for D1301StateUpdatePacket {
                         d1301::structures::IncomingCallsDuringBluetoothMode::take,
                     ),
                     (
-                        take(4usize),
+                        take(2usize),
+                        d1301::structures::PostSleepAudio::take,
+                        take(1usize),
                         d1301::structures::TapControlsDisabled::take,
                         d1301::structures::NoiseCancelingPrompt::take,
+                        d1301::structures::AutoSwitchOnceAsleep::take,
                     ),
                 ),
                 |(
@@ -124,7 +134,14 @@ impl FromPacketBody for D1301StateUpdatePacket {
                         noise_canceling,
                         incoming_calls_during_bluetooth_mode,
                     ),
-                    (_unknown7, tap_controls_disabled, noise_canceling_prompt),
+                    (
+                        _unknown7,
+                        post_sleep_audio,
+                        _unknown8,
+                        tap_controls_disabled,
+                        noise_canceling_prompt,
+                        auto_switch_once_asleep,
+                    ),
                 )| Self {
                     tws_status,
                     dual_battery_level,
@@ -141,6 +158,8 @@ impl FromPacketBody for D1301StateUpdatePacket {
                     incoming_calls_during_bluetooth_mode,
                     tap_controls_disabled,
                     noise_canceling_prompt,
+                    post_sleep_audio,
+                    auto_switch_once_asleep,
                 },
             ),
         )
@@ -165,7 +184,7 @@ impl ToPacket for D1301StateUpdatePacket {
             .chain(iter::repeat_n(0, 6))
             .chain(self.case_firmware_version.bytes())
             .chain(iter::repeat_n(0, 4))
-            .chain(iter::once(6)) // auto switch once asleep but unknown how it works
+            .chain(iter::once(6)) // see the matching comment in take()
             .chain(
                 self.button_configuration
                     .bytes(d1301::BUTTON_CONFIGURATION_SETTINGS.parse_settings()),
@@ -181,11 +200,87 @@ impl ToPacket for D1301StateUpdatePacket {
             .chain(iter::once(0))
             .chain(self.noise_canceling.bytes())
             .chain(self.incoming_calls_during_bluetooth_mode.bytes())
-            .chain(iter::repeat_n(0, 4))
+            .chain(iter::repeat_n(0, 2))
+            .chain(self.post_sleep_audio.bytes())
+            .chain(iter::once(0))
             .chain(self.tap_controls_disabled.bytes())
             .chain(self.noise_canceling_prompt.bytes())
+            .chain(self.auto_switch_once_asleep.bytes())
             .collect()
     }
 }
 
 state_update_packet_module!(D1301State, D1301StateUpdatePacket);
+
+#[cfg(test)]
+mod tests {
+    use nom_language::error::VerboseError;
+
+    use crate::devices::soundcore::common::packet::inbound::TryToPacket;
+
+    use super::*;
+
+    /// State update bodies captured from a Sleep A30 on firmware 01.91, one for
+    /// each of the three values the official app offers. Byte 148 is the enable
+    /// flag and byte 144 is the action; Keep Audio only clears the flag, so the
+    /// action it retains is whatever was set last.
+    const KEEP_AUDIO: &[u8] = &[
+        1, 1, 9, 9, 48, 49, 46, 57, 49, 48, 49, 46, 57, 49, 49, 51, 48, 49, 55, 67, 69, 57, 49, 51,
+        48, 55, 56, 67, 56, 65, 199, 37, 26, 19, 233, 124, 48, 49, 46, 54, 56, 0, 0, 0, 0, 6, 221,
+        136, 17, 0, 255, 0, 1, 104, 1, 124, 0, 50, 0, 255, 255, 1, 255, 255, 255, 0, 0, 1, 0, 0,
+        50, 38, 0, 0, 6, 0, 127, 219, 58, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1,
+        128, 0, 0, 0, 0, 0, 0, 4, 3, 2, 128, 0, 0, 0, 0, 0, 0, 4, 4, 3, 128, 0, 0, 0, 0, 0, 0, 4,
+        5, 4, 128, 0, 0, 0, 0, 0, 0, 4, 1, 0, 0, 1, 9, 0, 0, 1, 1, 1, 0, 0, 1, 0, 0,
+    ];
+    const PAUSE_AUDIO: &[u8] = &[
+        1, 1, 9, 9, 48, 49, 46, 57, 49, 48, 49, 46, 57, 49, 49, 51, 48, 49, 55, 67, 69, 57, 49, 51,
+        48, 55, 56, 67, 56, 65, 199, 37, 26, 19, 233, 124, 48, 49, 46, 54, 56, 0, 0, 0, 0, 6, 221,
+        136, 17, 0, 255, 0, 1, 104, 1, 124, 0, 50, 0, 255, 255, 0, 255, 255, 255, 0, 0, 1, 0, 0,
+        50, 38, 0, 0, 6, 0, 127, 219, 58, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1,
+        128, 0, 0, 0, 0, 0, 0, 4, 3, 2, 128, 0, 0, 0, 0, 0, 0, 4, 4, 3, 128, 0, 0, 0, 0, 0, 0, 4,
+        5, 4, 128, 0, 0, 0, 0, 0, 0, 4, 1, 0, 0, 1, 9, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0,
+    ];
+    const PLAY_LOCAL_AUDIO: &[u8] = &[
+        1, 1, 9, 9, 48, 49, 46, 57, 49, 48, 49, 46, 57, 49, 49, 51, 48, 49, 55, 67, 69, 57, 49, 51,
+        48, 55, 56, 67, 56, 65, 199, 37, 26, 19, 233, 124, 48, 49, 46, 54, 56, 0, 0, 0, 0, 6, 221,
+        136, 17, 0, 255, 0, 1, 104, 1, 124, 0, 50, 0, 255, 255, 1, 255, 255, 255, 0, 0, 1, 0, 0,
+        50, 38, 0, 0, 6, 0, 127, 219, 58, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 1,
+        128, 0, 0, 0, 0, 0, 0, 4, 3, 2, 128, 0, 0, 0, 0, 0, 0, 4, 4, 3, 128, 0, 0, 0, 0, 0, 0, 4,
+        5, 4, 128, 0, 0, 0, 0, 0, 0, 4, 1, 0, 0, 1, 9, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0,
+    ];
+
+    fn parse(body: &[u8]) -> D1301StateUpdatePacket {
+        D1301StateUpdatePacket::take::<VerboseError<_>>(body)
+            .unwrap()
+            .1
+    }
+
+    #[test]
+    fn parses_auto_switch_once_asleep_from_captured_state() {
+        let keep = parse(KEEP_AUDIO);
+        assert!(!keep.auto_switch_once_asleep.0);
+
+        let pause = parse(PAUSE_AUDIO);
+        assert!(pause.auto_switch_once_asleep.0);
+        assert_eq!(
+            d1301::structures::PostSleepAudio::PAUSE,
+            pause.post_sleep_audio
+        );
+
+        let play_local = parse(PLAY_LOCAL_AUDIO);
+        assert!(play_local.auto_switch_once_asleep.0);
+        assert_eq!(
+            d1301::structures::PostSleepAudio::PLAY_LOCAL,
+            play_local.post_sleep_audio
+        );
+    }
+
+    #[test]
+    fn serialize_and_deserialize() {
+        let bytes = D1301StateUpdatePacket::default()
+            .to_packet()
+            .bytes_with_checksum();
+        let (_, packet) = packet::Inbound::take_with_checksum::<VerboseError<_>>(&bytes).unwrap();
+        let _: D1301StateUpdatePacket = packet.try_to_packet().unwrap();
+    }
+}

--- a/lib/src/devices/soundcore/d1301/packets/outbound.rs
+++ b/lib/src/devices/soundcore/d1301/packets/outbound.rs
@@ -2,7 +2,9 @@ use std::iter;
 
 use crate::devices::soundcore::{
     common::packet,
-    d1301::structures::{AutoStopTimer, DefaultListeningMode, ListeningMode},
+    d1301::structures::{
+        AutoStopTimer, AutoSwitchOnceAsleep, DefaultListeningMode, ListeningMode, PostSleepAudio,
+    },
 };
 
 pub fn request_auto_stop_timer() -> packet::Outbound {
@@ -32,6 +34,22 @@ pub fn set_auto_stop_timer(auto_stop_timer: &AutoStopTimer) -> packet::Outbound 
 // pub fn delete_alarm(alarm_id: u8) -> packet::Outbound {
 //     packet::Outbound::new(packet::Command([20, 130]), vec![alarm_id])
 // }
+
+pub fn set_auto_switch_once_asleep(enabled: AutoSwitchOnceAsleep) -> packet::Outbound {
+    packet::Outbound::new(packet::Command([21, 143]), enabled.bytes().to_vec())
+}
+
+/// Set the post-sleep audio action.
+///
+/// Shares command 21 133 with [`set_auto_stop_timer`], but the official app
+/// fills the timer fields with 0xFF sentinels so they are left alone. We send
+/// the identical bytes rather than writing timer state back.
+pub fn set_post_sleep_audio(post_sleep_audio: PostSleepAudio) -> packet::Outbound {
+    packet::Outbound::new(
+        packet::Command([21, 133]),
+        vec![0xFF, 0xFF, 0xFF, post_sleep_audio.0],
+    )
+}
 
 pub fn set_listening_mode(listening_mode: ListeningMode) -> packet::Outbound {
     packet::Outbound::new(packet::Command([1, 169]), listening_mode.bytes().collect())

--- a/lib/src/devices/soundcore/d1301/state.rs
+++ b/lib/src/devices/soundcore/d1301/state.rs
@@ -31,6 +31,8 @@ pub struct D1301State {
     incoming_calls_during_bluetooth_mode: d1301::structures::IncomingCallsDuringBluetoothMode,
     tap_controls_disabled: d1301::structures::TapControlsDisabled,
     noise_canceling_prompt: d1301::structures::NoiseCancelingPrompt,
+    post_sleep_audio: d1301::structures::PostSleepAudio,
+    auto_switch_once_asleep: d1301::structures::AutoSwitchOnceAsleep,
     button_reset_pending: ResetButtonConfigurationPending,
 
     auto_stop_timer: d1301::structures::AutoStopTimer,
@@ -60,6 +62,8 @@ impl D1301State {
                 .incoming_calls_during_bluetooth_mode,
             tap_controls_disabled: state_update_packet.tap_controls_disabled,
             noise_canceling_prompt: state_update_packet.noise_canceling_prompt,
+            post_sleep_audio: state_update_packet.post_sleep_audio,
+            auto_switch_once_asleep: state_update_packet.auto_switch_once_asleep,
             button_reset_pending: ResetButtonConfigurationPending::default(),
             auto_stop_timer,
             alarms,
@@ -85,6 +89,8 @@ impl Update<D1301StateUpdatePacket> for D1301State {
             incoming_calls_during_bluetooth_mode,
             tap_controls_disabled,
             noise_canceling_prompt,
+            post_sleep_audio,
+            auto_switch_once_asleep,
         } = partial;
         self.tws_status = tws_status;
         self.dual_battery_level = dual_battery_level;
@@ -101,5 +107,7 @@ impl Update<D1301StateUpdatePacket> for D1301State {
         self.incoming_calls_during_bluetooth_mode = incoming_calls_during_bluetooth_mode;
         self.tap_controls_disabled = tap_controls_disabled;
         self.noise_canceling_prompt = noise_canceling_prompt;
+        self.post_sleep_audio = post_sleep_audio;
+        self.auto_switch_once_asleep = auto_switch_once_asleep;
     }
 }

--- a/lib/src/devices/soundcore/d1301/structures.rs
+++ b/lib/src/devices/soundcore/d1301/structures.rs
@@ -18,6 +18,27 @@ flag!(NoiseCanceling);
 flag!(IncomingCallsDuringBluetoothMode);
 flag!(TapControlsDisabled);
 flag!(NoiseCancelingPrompt);
+flag!(AutoSwitchOnceAsleep);
+
+/// What the earbuds do with audio once they detect you are asleep. Only
+/// meaningful while [`AutoSwitchOnceAsleep`] is enabled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct PostSleepAudio(pub u8);
+
+impl PostSleepAudio {
+    pub const PAUSE: Self = Self(0);
+    pub const PLAY_LOCAL: Self = Self(1);
+
+    pub fn take<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
+        input: &'a [u8],
+    ) -> IResult<&'a [u8], Self, E> {
+        context("post sleep audio", map(le_u8, Self)).parse_complete(input)
+    }
+
+    pub fn bytes(&self) -> [u8; 1] {
+        [self.0]
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct DefaultListeningMode(pub ListeningMode);


### PR DESCRIPTION
Adds the "Auto-Switch Once Asleep" setting for the Sleep A30 (D1301), and fixes an unhandled inbound packet on the same device.

I have a Sleep A30, so this is derived from and verified against real hardware (firmware 01.91, case 01.68). Closes #205, which is still open even though D1301 support landed in August.

## It is two bytes, not one value

The state update parser currently has:

```rust
take(4usize),
le_u8, // auto switch once asleep, but unknown how it works
```

That byte is at offset 45. It reads `6` on my device and on all three devices posted in #205, and it did not change across any capture where I changed the setting, so it does not appear to be this setting. I have corrected the comment but left the byte parsed and ignored as before, since I do not know what it is.

The setting is two independent bytes, both in the state update packet:

| Setting | enable flag (byte 148) | audio action (byte 144) |
|---|---|---|
| Keep Audio | 0 | *(retained)* |
| Pause Audio | 1 | 0 |
| Play Local Audio, ANC Off | 1 | 1 |

- **enable flag**: byte 148, previously unparsed. Set with command `21 143`.
- **audio action**: byte 144, previously unparsed. Set with command `21 133`.

The action is retained while the feature is disabled, which is why Keep Audio only clears the enable flag.

The first version of this PR read the action out of the `AutoStopTimer` packet instead. That byte mirrors the action on my hardware, so my captures and my hardware test agreed with each other while both pointed at the wrong byte. @Oppzippy caught it with the device faker, which feeds the official app directly and shows which byte the app really reads. `AutoStopTimer` is now left exactly as it was upstream.

`set_post_sleep_audio` sends `FF FF FF <action>`, byte for byte what the official app sends. Command `21 133` also carries the auto stop timer, and the `0xFF` values are the sentinels the app uses to leave those fields alone, so the timer state is not written back.

## Second commit: unhandled `21 3`

`AutoStopTimerPacket` had no registered inbound handler, so every timer change logged:

```
WARN no handler found for inbound packet: Packet { command: Command([21, 3]), body: [...] }
```

Beyond the noise, the packet was only requested at startup, so a timer change made on the device or from the official app was not reflected until reconnect. This commit stands alone and is unrelated to the setting above, so say the word if you would rather have it separately.

## How it was derived

Two independent methods that agree:

1. Diffing state update packets while changing the setting in the official app.
2. An Android HCI snoop log of the app making those same changes.

Controls: re-reading with nothing changed produced a byte-identical packet, so the differences are not drift. Toggling the ANC on/off prompt tone changed only byte 147 and the CLI then reported `noiseCancelingPrompt false`, which separates 147 from 148. That is worth noting, because naive offset arithmetic puts `noiseCancelingPrompt` at 148.

## Verification

Reads track changes made in the official app. All three values were then written from openscq30 and confirmed in the official app, including the Keep Audio to Play Local Audio transition that sends both commands. Byte-level state after each write matches the table above.

Three of those captured state update bodies, one per value, are included as a parser test.

`cargo test`, `cargo clippy` and `cargo fmt --check` are clean.

## Known limitations

- State bytes 61 and 144 moved together in every capture across four devices, and the app cannot produce a state where they would differ, so my captures alone cannot tell them apart. The faker settles it: the app reads 144.
- `15 03` reports only the action, not the enable flag. I verified this by disabling the feature and re-reading: the reply was unchanged while state byte 148 flipped. Both are read from the state update packet instead.
