### PR TITLE
feat(lib): verify the d1301 alarm write commands

### DIFF
--- a/lib/src/devices/soundcore/d1301/packets/outbound.rs
+++ b/lib/src/devices/soundcore/d1301/packets/outbound.rs
@@ -3,7 +3,8 @@ use std::iter;
 use crate::devices::soundcore::{
     common::packet,
     d1301::structures::{
-        AutoStopTimer, AutoSwitchOnceAsleep, DefaultListeningMode, ListeningMode, PostSleepAudio,
+        Alarm, AutoStopTimer, AutoSwitchOnceAsleep, DefaultListeningMode, ListeningMode,
+        PostSleepAudio,
     },
 };
 
@@ -26,14 +27,25 @@ pub fn set_auto_stop_timer(auto_stop_timer: &AutoStopTimer) -> packet::Outbound 
     )
 }
 
-// TODO
-// pub fn set_alarm(alarm: &Alarm) -> packet::Outbound {
-//     packet::Outbound::new(packet::Command([20, 129]), alarm.bytes().collect())
-// }
+/// Create or update an alarm.
+///
+/// The body is [`Alarm::bytes`] unchanged: id, enabled, time as little endian
+/// minutes past midnight, repeat bitflags, tune, volume, snooze minutes.
+/// Updating an existing alarm sends the whole record with the same id.
+///
+/// Not yet reachable from a setting: alarms are a list of records, and there is
+/// no `Setting` variant that can edit one. Kept here, verified, so that whoever
+/// adds that primitive does not have to rediscover the wire format.
+#[allow(dead_code)]
+pub fn set_alarm(alarm: &Alarm) -> packet::Outbound {
+    packet::Outbound::new(packet::Command([20, 129]), alarm.bytes().collect())
+}
 
-// pub fn delete_alarm(alarm_id: u8) -> packet::Outbound {
-//     packet::Outbound::new(packet::Command([20, 130]), vec![alarm_id])
-// }
+/// Delete the alarm with this id.
+#[allow(dead_code)]
+pub fn delete_alarm(alarm_id: u8) -> packet::Outbound {
+    packet::Outbound::new(packet::Command([20, 130]), vec![alarm_id])
+}
 
 pub fn set_auto_switch_once_asleep(enabled: AutoSwitchOnceAsleep) -> packet::Outbound {
     packet::Outbound::new(packet::Command([21, 143]), enabled.bytes().to_vec())
@@ -57,4 +69,59 @@ pub fn set_listening_mode(listening_mode: ListeningMode) -> packet::Outbound {
 
 pub fn set_default_listening_mode(listening_mode: DefaultListeningMode) -> packet::Outbound {
     packet::Outbound::new(packet::Command([16, 149]), listening_mode.bytes().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::devices::soundcore::d1301::structures::{AlarmRepeat, AlarmVolume, AlarmWakeUpTune};
+
+    /// Captured from a Sleep A30 while adding an alarm in the official app:
+    /// 09:20, weekends, Nature, volume 50, snooze 10 minutes, in slot 1.
+    #[test]
+    fn set_alarm_matches_a_captured_packet() {
+        const EXPECTED: &[u8] = &[
+            0x08, 0xee, 0x00, 0x00, 0x00, 0x14, 0x81, 0x12, 0x00, 0x01, 0x01, 0x30, 0x02, 0x82,
+            0x00, 0x32, 0x0a, 0x8f,
+        ];
+        let alarm = Alarm {
+            id: 1,
+            is_enabled: true,
+            time: 560, // 09:20
+            repeat: AlarmRepeat::SATURDAY | AlarmRepeat::SUNDAY,
+            wake_up_tune: AlarmWakeUpTune::Nature,
+            volume: AlarmVolume::new(50),
+            snooze_duration_in_minutes: 10,
+        };
+        assert_eq!(EXPECTED, set_alarm(&alarm).bytes_with_checksum());
+    }
+
+    /// Captured while editing the alarm already in slot 0. Updating sends the
+    /// whole record with the same id rather than a partial change.
+    #[test]
+    fn set_alarm_updates_an_existing_alarm() {
+        const EXPECTED: &[u8] = &[
+            0x08, 0xee, 0x00, 0x00, 0x00, 0x14, 0x81, 0x12, 0x00, 0x00, 0x01, 0xd1, 0x01, 0x00,
+            0x01, 0x32, 0x05, 0xa8,
+        ];
+        let alarm = Alarm {
+            id: 0,
+            is_enabled: true,
+            time: 465, // 07:45
+            repeat: AlarmRepeat::empty(),
+            wake_up_tune: AlarmWakeUpTune::Glow,
+            volume: AlarmVolume::new(50),
+            snooze_duration_in_minutes: 5,
+        };
+        assert_eq!(EXPECTED, set_alarm(&alarm).bytes_with_checksum());
+    }
+
+    /// Captured from the same session while deleting the alarm in slot 1.
+    #[test]
+    fn delete_alarm_matches_a_captured_packet() {
+        const EXPECTED: &[u8] = &[
+            0x08, 0xee, 0x00, 0x00, 0x00, 0x14, 0x82, 0x0b, 0x00, 0x01, 0x98,
+        ];
+        assert_eq!(EXPECTED, delete_alarm(1).bytes_with_checksum());
+    }
 }


### PR DESCRIPTION
`set_alarm` and `delete_alarm` were commented out with a `TODO` and guessed command ids. Both guesses were correct.

I have a Sleep A30, so I captured an Android HCI snoop log of the official app editing, adding and deleting alarms, and compared it against what was already written. The commands and the body layout match exactly.

```
20 129   set alarm      body is Alarm::bytes() unchanged
20 130   delete alarm   body is a single id byte
```

## What the capture showed

Changing one field at a time, so each write differs from the last in a single byte:

| action in the app | captured body |
|---|---|
| set time to 07:45 | `00 01 D1 01 00 00 32 0A` |
| change tune to Glow | `00 01 D1 01 00 01 32 0A` |
| change snooze to 5 minutes | `00 01 D1 01 00 01 32 05` |
| add a second alarm, 09:20, weekends | `01 01 30 02 82 00 32 0A` |
| delete that alarm | `01` on `20 130` |

Those decode against the existing `Alarm` struct with no changes: `id`, `is_enabled`, `time` as little endian minutes past midnight, `repeat` bitflags, `wake_up_tune`, `volume`, `snooze_duration_in_minutes`.

`0x82` is `SATURDAY | SUNDAY` against the existing `AlarmRepeat` flags, which confirms the day encoding. No earlier capture had exercised it.

Editing an existing alarm sends the whole record with the same id rather than a partial update, so one function covers create and update.

## Tests

Both tests assert the exact bytes from the log, checksum included, rather than whatever the code happens to produce. The checksums in the capture were `0x8f` and `0x98`, and the existing checksum code reproduces both.

## Why they are not wired to a setting

Alarms are a list of records, each with a time, days, tune, volume and snooze. Every `Setting` variant is a single value, so there is nowhere to put an alarm editor, and `AlarmsSettingHandler` currently returns `Information` with "not yet implemented" and `ReadOnly`.

That looks like the real reason this was left undone, rather than the packets. Adding a list editing primitive touches the GUI, CLI, Android and the uniffi bindings, and that is your architecture to decide, so I have not attempted it. The functions are marked `allow(dead_code)` so the verified format is recorded for whoever does.

Happy to run more captures on this device if that would help, including a first pass at the toggle only case if a simple per alarm `Toggle` would be acceptable.
