### PR TITLE
Fix Android 11 and below never seeing paired devices due to BLUETOOTH_CONNECT check

### DIFF
--- a/android/app/src/main/java/com/oppzippy/openscq30/features/soundcoredevice/ConnectionBackends.kt
+++ b/android/app/src/main/java/com/oppzippy/openscq30/features/soundcoredevice/ConnectionBackends.kt
@@ -6,6 +6,7 @@ import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothSocket
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.Log
 import androidx.core.app.ActivityCompat
 import com.oppzippy.openscq30.R
@@ -46,6 +47,7 @@ class AndroidRfcommConnectionBackendImpl(private val context: Context, private v
             }
 
             if (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
                 ActivityCompat.checkSelfPermission(
                     context,
                     Manifest.permission.BLUETOOTH_CONNECT,
@@ -83,7 +85,8 @@ class AndroidRfcommConnectionBackendImpl(private val context: Context, private v
         serviceSelectionStrategy: RfcommServiceSelectionStrategy,
         outputBox: ManualRfcommConnectionBox,
     ) {
-        if (ActivityCompat.checkSelfPermission(
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S &&
+            ActivityCompat.checkSelfPermission(
                 context,
                 Manifest.permission.BLUETOOTH_CONNECT,
             ) != PackageManager.PERMISSION_GRANTED


### PR DESCRIPTION
The BLUETOOTH_CONNECT permission was not introduced until API 31. On Android 11 and below, checkSelfPermission for BLUETOOTH_CONNECT always returns "denied", causing  devices() and connect() to silently return nothing on older Android versions.

By removing the BLUETOOTH_CONNECT permission check for Android 11 and below, older Android versions now show all paired devices as options to select within the app once they are paired at the OS level (from Bluetooth Settings).

Successfully tested and validated discovery and functionality of Soundcore Space A40 on device running Android 11.

Fixes #367